### PR TITLE
🐛 Fix : 백드롭 클릭 시 모달이 닫히지 않는 문제 해결

### DIFF
--- a/src/components/TeamSelectModal/index.tsx
+++ b/src/components/TeamSelectModal/index.tsx
@@ -48,7 +48,11 @@ export default function TeamSelectModal() {
 
       <TeamStyle.TeamDialog
         ref={dialogRef}
-        onClose={closeModal}
+        onClick={(e) => {
+          if (e.target === dialogRef.current) {
+            closeModal(); // 백드롭 클릭 시 닫기
+          }
+        }}
       >
         <h2>마이팀 선택</h2>
         <TeamStyle.AllButton onClick={() => handleTeamSelect('전체')}>


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 백드롭 클릭 시 모달이 닫히지 않는 문제 해결

## 📝 구현한 내용
- 이벤트가 다이얼로그 내부 요소로부터 발생했는지 확인하기 위해 e.target === dialogRef.current 조건을 사용

## ✅ 체크리스트
- [x] margin-bottom 값 추후 확인 필요

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- fixed #10 
