### PR TITLE
✨ Feat : 알약 버튼 마크업 완료 #7

### DIFF
--- a/src/components/PillButton/index.tsx
+++ b/src/components/PillButton/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { ButtonWrapper } from './style'
+
+interface PillButtonProps {
+  defaultSelected?: boolean // 기본 상태: 선택 여부
+  text: string // 버튼에 표시할 텍스트
+  disabled?: boolean // 기본 비활성화 상태
+}
+
+const PillButton = ({
+  defaultSelected = false,
+  text,
+  disabled = false,
+}: PillButtonProps) => {
+  const [isSelected, setIsSelected] = useState(defaultSelected)
+  const [isDisabled, setIsDisabled] = useState(disabled)
+
+  const handleClick = () => {
+    if (isDisabled) return // 비활성화 상태에서는 클릭하지 않음
+    setIsSelected((prev) => !prev) // 선택 전/후 상태 토글
+  }
+
+  return (
+    <ButtonWrapper
+      isSelected={isSelected}
+      onClick={handleClick}
+      disabled={isDisabled}
+    >
+      {text}
+    </ButtonWrapper>
+  )
+}
+
+export default PillButton

--- a/src/components/PillButton/index.tsx
+++ b/src/components/PillButton/index.tsx
@@ -1,34 +1,22 @@
-import { useState } from 'react'
-import { ButtonWrapper } from './style'
+import { ButtonWrapper } from './style';
 
 interface PillButtonProps {
-  defaultSelected?: boolean // 기본 상태: 선택 여부
-  text: string // 버튼에 표시할 텍스트
-  disabled?: boolean // 기본 비활성화 상태
+  text: string;
+  isSelected: boolean; // 선택 상태
+  disabled?: boolean; // 비활성화 상태
+  onClick: () => void; // 클릭 이벤트 핸들러
 }
 
-const PillButton = ({
-  defaultSelected = false,
-  text,
-  disabled = false,
-}: PillButtonProps) => {
-  const [isSelected, setIsSelected] = useState(defaultSelected)
-  const [isDisabled, setIsDisabled] = useState(disabled)
-
-  const handleClick = () => {
-    if (isDisabled) return // 비활성화 상태에서는 클릭하지 않음
-    setIsSelected((prev) => !prev) // 선택 전/후 상태 토글
-  }
-
+const PillButton = ({ text, isSelected, disabled = false, onClick }: PillButtonProps) => {
   return (
     <ButtonWrapper
       isSelected={isSelected}
-      onClick={handleClick}
-      disabled={isDisabled}
+      onClick={disabled ? undefined : onClick} // 비활성화 상태에서는 클릭 비활성화
+      disabled={disabled}
     >
       {text}
     </ButtonWrapper>
-  )
-}
+  );
+};
 
-export default PillButton
+export default PillButton;

--- a/src/components/PillButton/style.ts
+++ b/src/components/PillButton/style.ts
@@ -1,0 +1,42 @@
+import styled, { css } from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const ButtonWrapper = styled.button<{ isSelected: boolean }>`
+  all: unset;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.5em 1em;
+  border-radius: 9999px;
+  font-size: ${theme.fontSize.large};
+  font-weight: ${theme.fontWeight.semi};
+  cursor: pointer;
+  transition:
+    background-color 0.3s,
+    color 0.3s;
+
+  ${(props) =>
+    props.isSelected
+      ? css`
+          background-color: ${theme.teams.kbo};
+          color: ${theme.fontColor.white};
+          &:hover {
+            background-color: ${theme.teams.kbo}D9;
+          }
+        `
+      : css`
+          background-color: ${theme.fontColor.cwhite};
+          color: ${theme.fontColor.black};
+          &:hover {
+            background-color: #d6d6d6;
+          }
+        `};
+
+  ${(props) =>
+    props.disabled &&
+    css`
+      background-color: #d9d9d9;
+      color: ${theme.fontColor.black}80;
+      cursor: not-allowed;
+    `};
+`

--- a/src/components/PillButtonList/index.tsx
+++ b/src/components/PillButtonList/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { ListWrapper, ScrollWrapper } from './style';
+import PillButton from '@components/PillButton';
+
+// PillButtonList 컴포넌트의 props 타입 정의
+interface PillButtonListProps {
+  buttons: { id: string; text: string; disabled?: boolean }[]; // 버튼 데이터 배열
+  mode: 'radio' | 'tab'; // 버튼 모드: 라디오 버튼 / 탭 버튼
+  defaultSelected?: string; // 초기 선택 버튼 ID (선택 사항)
+  onSelect?: (id: string) => void; // 선택된 버튼 ID를 전달하는 콜백
+}
+
+const PillButtonList = ({
+  buttons,
+  mode,
+  defaultSelected,
+  onSelect,
+}: PillButtonListProps) => {
+  // 기본 선택 버튼 ID 계산
+  // - `defaultSelected`가 주어졌고, 해당 버튼이 활성화된 경우 기본값으로 사용
+  // - 그렇지 않으면, 버튼 목록에서 첫 번째 활성화된 버튼을 기본값으로 설정
+  const initialSelected =
+    defaultSelected && !buttons.find((button) => button.id === defaultSelected)?.disabled
+      ? defaultSelected
+      : buttons.find((button) => !button.disabled)?.id || ''; // 비활성화되지 않은 첫 버튼 ID
+
+  // 선택된 버튼의 ID를 상태로 관리
+  const [selectedId, setSelectedId] = useState(initialSelected);
+
+  // 컴포넌트가 렌더링되거나 `defaultSelected` 또는 `buttons`가 변경될 때 실행
+  useEffect(() => {
+    // `defaultSelected`가 유효하고 활성화된 버튼인지 확인
+    const validDefault =
+      defaultSelected && !buttons.find((button) => button.id === defaultSelected)?.disabled;
+
+    // `defaultSelected`가 유효하지 않으면 첫 번째 활성화된 버튼을 선택
+    const fallback = buttons.find((button) => !button.disabled)?.id || '';
+    setSelectedId(validDefault ? defaultSelected : fallback); // 선택 상태 업데이트
+  }, [defaultSelected, buttons]);
+
+  // 버튼 클릭 핸들러
+  const handleClick = (id: string) => {
+    if (id === selectedId) return; // 이미 선택된 버튼이면 동작하지 않음
+    setSelectedId(id); // 선택된 버튼의 ID 업데이트
+    if (onSelect) onSelect(id); // 부모 컴포넌트로 선택된 버튼 ID 전달
+  };
+
+  // 모드에 따라 다른 Wrapper 컴포넌트 선택
+  const WrapperComponent = mode === 'tab' ? ScrollWrapper : ListWrapper;
+
+  return (
+    <WrapperComponent>
+      {/* 버튼 목록 렌더링 */}
+      {buttons.map((button) => (
+        <PillButton
+          key={button.id} // 고유 키 설정
+          text={button.text} // 버튼 텍스트
+          isSelected={selectedId === button.id} // 선택 상태 전달
+          disabled={button.disabled} // 비활성화 상태 전달
+          onClick={() => handleClick(button.id)} // 클릭 이벤트 핸들러
+        />
+      ))}
+    </WrapperComponent>
+  );
+};
+
+export default PillButtonList;

--- a/src/components/PillButtonList/style.ts
+++ b/src/components/PillButtonList/style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const ListWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625em; /* 버튼 간격 */
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+export const ScrollWrapper = styled.div`
+  display: flex;
+  overflow-x: auto;
+  white-space: nowrap;
+  gap: 0.625em;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  & > * {
+    flex-shrink: 0;
+  }
+`;


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 알약 버튼 마크업
- PillButtonList 컴포넌트 개발 및 스타일링
- PillButton 컴포넌트 구현 및 선택/비활성화 상태 관리
- 버튼 목록 모드(라디오, 탭)별 렌더링 로직 추가

## 📝 구현한 내용
- `PillButtonList`
  - **버튼 목록 관리**: 버튼 데이터를 받아 라디오 모드와 탭 모드에 따라 렌더링
  - **선택 상태 관리**: 선택된 버튼의 ID를 상태로 관리하며, 클릭 시 상태를 업데이트
  - **초기 값 처리**:
    - `defaultSelected`가 유효하면 해당 버튼을 기본 선택으로 설정
    - `defaultSelected`가 없거나 비활성화된 버튼일 경우, 활성화된 첫 버튼을 기본값으로 설정
  - **스타일링**:
    - 라디오 모드(`ListWrapper`)에서는 줄바꿈을 허용
    - 탭 모드(`ScrollWrapper`)에서는 가로 스크롤 및 스크롤바 숨김 처리
- `PillButton`
  - **선택 상태 표시**: `isSelected` Prop을 통해 버튼의 선택 상태를 표시
  - **비활성화 상태 처리**: `disabled` Prop을 통해 비활성화된 버튼은 클릭되지 않도록 처리
  - **스타일링**: 버튼 상태에 따른 동적 스타일 적용
- **스타일 파일 추가**
  - `ListWrapper`와 `ScrollWrapper`로 모드에 따라 레이아웃을 구분
  - 버튼 간 간격과 스크롤 숨김 스타일 처리

![스크린샷 2024-11-24 14 59 30](https://github.com/user-attachments/assets/962a330f-0744-4369-959a-68b3740b9980)
![스크린샷 2024-11-24 14 59 34](https://github.com/user-attachments/assets/735cf152-5c03-4226-8bac-063eca064e2e)
![스크린샷 2024-11-24 14 59 56](https://github.com/user-attachments/assets/0f32bd8b-704f-4880-9189-4cd0e2ae8218)
![스크린샷 2024-11-24 17 47 56](https://github.com/user-attachments/assets/c5c2a659-b27d-4340-aacb-d312c7d400c4)


## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- "카테고리 모달"에서 항목당 하나만 선택한다는 가정하에, 하나만 선택할 수 있도록 작성함..

## 🔗 연관된 이슈
- close #7 
