### PR TITLE
Feat/#60 굿즈 거래 상세페이지 마크업

### DIFF
--- a/src/pages/GoodsDetailPage/index.tsx
+++ b/src/pages/GoodsDetailPage/index.tsx
@@ -1,0 +1,137 @@
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Pagination } from 'swiper/modules'
+import {
+  GoodsBedgeWrap,
+  GoodsBottomButton,
+  GoodsBottomButtonWrap,
+  GoodsBottomWrap,
+  GoodsDetailMapInner,
+  GoodsDetailMapWrap,
+  GoodsDetailText,
+  GoodsDetailTop,
+  GoodsNoticeWrap,
+  GoodsPriceText,
+  PaginationContainer,
+  SwiperContainer,
+  SwiperSlideInner,
+} from './style'
+
+import 'swiper/css'
+import 'swiper/css/pagination'
+import UserInfoList from '@components/UserInfoList'
+import CardBedge from '@components/CardBedge'
+import { GlobalFloatAside } from '@styles/globalStyle'
+import { useState } from 'react'
+import Form from '@components/Form'
+
+const GoodsDetailPage = () => {
+  const [isOner, setIsOner] = useState(false)
+  const [isAble, setIsAble] = useState(false)
+
+  return (
+    <section>
+      <SwiperContainer>
+        <Swiper
+          spaceBetween={0}
+          slidesPerView={1}
+          pagination={{ el: '.custom-pagination', clickable: true }}
+          modules={[Pagination]}
+        >
+          <SwiperSlide>
+            <SwiperSlideInner>
+              <img
+                src='https://www.womansense.co.kr/upload/woman/article/201906/thumb/42093-370390-sampleM.jpg'
+                alt=''
+              />
+            </SwiperSlideInner>
+          </SwiperSlide>
+          <SwiperSlide>
+            <SwiperSlideInner>
+              <img
+                src='https://www.womansense.co.kr/upload/woman/article/201906/thumb/42093-370390-sampleM.jpg'
+                alt=''
+              />
+            </SwiperSlideInner>
+          </SwiperSlide>
+          <SwiperSlide>
+            <SwiperSlideInner>
+              <img
+                src='https://www.womansense.co.kr/upload/woman/article/201906/thumb/42093-370390-sampleM.jpg'
+                alt=''
+              />
+            </SwiperSlideInner>
+          </SwiperSlide>
+        </Swiper>
+        <PaginationContainer className='custom-pagination' />
+      </SwiperContainer>
+      <GoodsDetailTop>
+        <GoodsBedgeWrap>
+          <div>
+            <CardBedge text='모자' />
+            <CardBedge text='NC' />
+          </div>
+          <div>
+            {isAble ? (
+              <CardBedge text='거래중' />
+            ) : (
+              <CardBedge text='거래완료' />
+            )}
+          </div>
+        </GoodsBedgeWrap>
+        <p>NC 다이노스 배틀크러쉬 모자</p>
+        <UserInfoList />
+      </GoodsDetailTop>
+
+      <GoodsNoticeWrap>
+        <GoodsDetailText>
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+          여기 내용이 들어갑니다 <br />
+        </GoodsDetailText>
+        <GoodsDetailMapWrap>
+          <h2>거래 장소</h2>
+          <p>초등학교 앞</p>
+          <GoodsDetailMapInner>여기에 카카오맵</GoodsDetailMapInner>
+        </GoodsDetailMapWrap>
+      </GoodsNoticeWrap>
+
+      <GlobalFloatAside>
+        <GoodsBottomWrap>
+          <GoodsPriceText>00,000원</GoodsPriceText>
+          <GoodsBottomButtonWrap>
+            {isOner ? (
+              <>
+                <GoodsBottomButton $isNavy={true}>삭제하기</GoodsBottomButton>
+                <GoodsBottomButton $isNavy={true}>수정하기</GoodsBottomButton>
+              </>
+            ) : isAble ? (
+              <GoodsBottomButton $isNavy={true}>대화 나누기</GoodsBottomButton>
+            ) : (
+              <GoodsBottomButton
+                $isNavy={false}
+                disabled={true}
+              >
+                대화 나누기
+              </GoodsBottomButton>
+            )}
+          </GoodsBottomButtonWrap>
+        </GoodsBottomWrap>
+      </GlobalFloatAside>
+    </section>
+  )
+}
+
+export default GoodsDetailPage

--- a/src/pages/GoodsDetailPage/index.tsx
+++ b/src/pages/GoodsDetailPage/index.tsx
@@ -22,7 +22,7 @@ import UserInfoList from '@components/UserInfoList'
 import CardBedge from '@components/CardBedge'
 import { GlobalFloatAside } from '@styles/globalStyle'
 import { useState } from 'react'
-import Form from '@components/Form'
+import { Map, MapMarker } from 'react-kakao-maps-sdk'
 
 const GoodsDetailPage = () => {
   const [isOner, setIsOner] = useState(false)
@@ -104,7 +104,14 @@ const GoodsDetailPage = () => {
         <GoodsDetailMapWrap>
           <h2>거래 장소</h2>
           <p>초등학교 앞</p>
-          <GoodsDetailMapInner>여기에 카카오맵</GoodsDetailMapInner>
+          <GoodsDetailMapInner>
+            <Map
+              center={{ lat: 33.5563, lng: 126.79581 }}
+              style={{ width: '100%', height: '115px' }}
+            >
+              <MapMarker position={{ lat: 33.55635, lng: 126.795841 }} />
+            </Map>
+          </GoodsDetailMapInner>
         </GoodsDetailMapWrap>
       </GoodsNoticeWrap>
 

--- a/src/pages/GoodsDetailPage/style.ts
+++ b/src/pages/GoodsDetailPage/style.ts
@@ -1,0 +1,168 @@
+import { theme } from '@styles/theme'
+import styled from 'styled-components'
+
+interface ButtonPropTypes {
+  $isNavy: boolean
+}
+
+export const SwiperContainer = styled.div`
+  position: relative;
+`
+
+export const SwiperSlideInner = styled.div`
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+
+  &::after {
+    content: '';
+    display: block;
+    padding-bottom: 93.75%;
+  }
+
+  & > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+`
+
+export const PaginationContainer = styled.div`
+  position: absolute;
+  bottom: 16px !important;
+  left: 50% !important;
+  transform: translateX(-50%);
+  z-index: 999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  .swiper-pagination-bullet {
+    width: 8px;
+    height: 8px;
+    background: #333741; /* 기본 색상 */
+    opacity: 1;
+    margin: 0 5px;
+  }
+  .swiper-pagination-bullet-active {
+    background: #cecfd2; /* 활성화된 색상 */
+  }
+`
+
+export const GoodsDetailTop = styled.div`
+  padding: 0.625em 20px;
+  border-bottom: 1px solid #cacaca;
+
+  & > p {
+    font-size: ${theme.fontSize.large};
+    font-weight: ${theme.fontWeight.medium};
+    color: ${theme.fontColor.black};
+    margin: 0.9375em 0;
+
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`
+
+export const GoodsBedgeWrap = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  & > div {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.5em;
+  }
+`
+
+export const GoodsBottomWrap = styled.div`
+  width: 100%;
+  padding: 1.25em 20px;
+  background-color: ${theme.fontColor.cwhite};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+export const GoodsPriceText = styled.p`
+  font-size: ${theme.fontSize.large};
+  font-weight: ${theme.fontWeight.semi};
+  color: ${theme.fontColor.black};
+  letter-spacing: -0.025em;
+`
+
+export const GoodsBottomButtonWrap = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 1em;
+`
+
+export const GoodsBottomButton = styled.button<ButtonPropTypes>`
+  appearance: none;
+  padding: 0.5em 1em;
+
+  font-size: ${theme.fontSize.large};
+  font-weight: ${theme.fontWeight.semi};
+  color: ${theme.fontColor.white};
+  background-color: ${({ $isNavy }) =>
+    $isNavy ? `${theme.fontColor.navy}` : `#D9D9D9`};
+  letter-spacing: -0.025em;
+
+  border-radius: 4px;
+`
+
+export const GoodsNoticeWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 2.1875em 20px;
+  gap: 2.1875em;
+`
+
+export const GoodsDetailText = styled.div`
+  width: 100%;
+  max-height: 190px;
+  overflow-y: scroll;
+  padding: 1em;
+  background-color: ${theme.fontColor.cwhite};
+  font-size: ${theme.fontSize.large};
+  font-weight: ${theme.fontWeight.medium};
+  color: ${theme.fontColor.black};
+  border-radius: 4px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`
+
+export const GoodsDetailMapWrap = styled.div`
+  width: 100%;
+  & > h2 {
+    font-size: ${theme.fontSize.xlarge};
+    font-weight: ${theme.fontWeight.semi};
+    color: ${theme.fontColor.black};
+  }
+
+  & > p {
+    width: 100%;
+    padding: 1em;
+    font-size: ${theme.fontSize.large};
+    font-weight: ${theme.fontWeight.medium};
+    color: ${theme.fontColor.black};
+    background-color: ${theme.fontColor.cwhite};
+    margin-top: 0.5em;
+    border-radius: 4px;
+  }
+`
+
+export const GoodsDetailMapInner = styled.div``

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,7 @@ import MateListPage from '@pages/MateListPage'
 import SplashPage from '@pages/SplashPage'
 import LoginPage from '@pages/LoginPage'
 import SignupPage from '@pages/LoginPage/SignupPage'
+import GoodsDetailPage from '@pages/GoodsDetailPage'
 
 const AppRoutes = () => {
   return (
@@ -48,6 +49,10 @@ const AppRoutes = () => {
         <Route
           path='/chat-room'
           element={<ChatRoom />}
+        />
+        <Route
+          path='/goodsdetail'
+          element={<GoodsDetailPage />}
         />
       </Route>
 


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 굿즈 거래 상세페이지 마크업

## 📝 구현한 내용
- 스와이퍼를 이용한 이미지 슬라이더
- 상품 정보 & 작성자 정보 마크업
- 거래 디테일 정보 마크업
- 카카오맵 렌더링
![image](https://github.com/user-attachments/assets/3ea21d14-a8c3-47df-a01d-55615253f7b8)

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 카카오맵 렌더링 확인
- 하단 영역 버튼 따로 만들었는데 체크부탁

## 🔗 연관된 이슈
- close (#60 )
