### PR TITLE
✨ Feat : 메이트 구인 상세 페이지 마크업 완성 #57

### DIFF
--- a/src/pages/MateDetailPage/MateDetailAction/index.tsx
+++ b/src/pages/MateDetailPage/MateDetailAction/index.tsx
@@ -1,0 +1,51 @@
+import {
+  MateDetailActionContainer,
+  Notice,
+  ActionSection,
+  ChattingPeople,
+  ActionButton,
+} from './style'
+
+const MateDetailAction = () => {
+  const isConditionMatched = false // 조건 일치 여부
+  const isRecruitmentComplete = false // 모집 완료 여부
+  const isHost = false // 방장 여부
+  const totalParticipants = 20 // 참여자 수
+
+  return (
+    <MateDetailActionContainer>
+      {/* 경고 메시지 */}
+      <Notice>
+        {!isConditionMatched && (
+          <span>⚠️ 이런! 모임에서 원하는 조건이 아니에요!</span>
+        )}
+      </Notice>
+
+      {/* 액션 영역 */}
+      <ActionSection>
+        {/* 참여자 표시 */}
+        <ChattingPeople>대화중인 메이트 - {totalParticipants}</ChattingPeople>
+
+        {/* 버튼 */}
+        <ActionButton>
+          {isHost ? (
+            <>
+              <button>삭제하기</button>
+              <button>수정하기</button>
+            </>
+          ) : isConditionMatched ? (
+            !isRecruitmentComplete ? (
+              <button>대화 나누기</button>
+            ) : (
+              <button disabled>모집 완료</button>
+            )
+          ) : (
+            <button disabled>대화 나누기</button>
+          )}
+        </ActionButton>
+      </ActionSection>
+    </MateDetailActionContainer>
+  )
+}
+
+export default MateDetailAction

--- a/src/pages/MateDetailPage/MateDetailAction/style.ts
+++ b/src/pages/MateDetailPage/MateDetailAction/style.ts
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import { theme } from "@styles/theme";
+
+export const MateDetailActionContainer = styled.div`
+  margin-top: 1em;
+`;
+
+export const Notice = styled.div`
+  color: #e00000;
+  font-weight: ${theme.fontWeight.semi};
+  font-size: ${theme.fontSize.medium};
+  margin-left: 1.25em;
+  margin-bottom: 1em;
+`;
+
+export const ActionSection = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1em 1.25em;
+  background-color: ${theme.fontColor.cwhite};
+`;
+
+export const ChattingPeople = styled.div`
+  color: #727272;
+  font-size: ${theme.fontSize.large};
+  font-weight: ${theme.fontWeight.semi};
+`;
+
+export const ActionButton = styled.div`
+  display: flex;
+  gap: 10px;
+
+  button {
+    padding: 0.5em 1em;
+    font-size: ${theme.fontSize.large};
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    background-color: ${theme.teams.kbo};
+    color: ${theme.fontColor.white};
+
+    &:disabled {
+      background-color: #d9d9d9;
+      color: #727272;
+      cursor: not-allowed;
+    }
+  }
+`;

--- a/src/pages/MateDetailPage/MateDetailCard/index.tsx
+++ b/src/pages/MateDetailPage/MateDetailCard/index.tsx
@@ -1,0 +1,38 @@
+import {
+    CardContainer,
+    CardContent,
+    CardContentLeft,
+    CardContentRight,
+    BedgeContainer,
+  Description,
+} from './style'
+import CardBedge from '@components/CardBedge'
+
+const MateDetailCard = () => {
+  return (
+    <CardContainer>  
+        <CardContent>
+          {/* 경기정보 */}
+          <CardContentLeft>
+            <Description>
+              <p>피치메이트</p>
+              <p>상대팀 : KT</p>
+              <p>11월 08일 13시 - 문학</p>
+            </Description>
+            <BedgeContainer>
+              <CardBedge />
+              <CardBedge />
+            </BedgeContainer>
+          </CardContentLeft>
+  
+          {/* 모집정보 */}
+          <CardContentRight>
+            <CardBedge text='모집중' />
+            <p>10명</p>
+          </CardContentRight>
+        </CardContent>
+      </CardContainer>
+  )
+}
+
+export default MateDetailCard

--- a/src/pages/MateDetailPage/MateDetailCard/style.ts
+++ b/src/pages/MateDetailPage/MateDetailCard/style.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components'
+
+export const CardContainer = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 16px;
+  padding: 1em 1.25em;
+  border-bottom: 1px solid ${({ theme }) => theme.fontColor.cwhite};
+`
+export const CardContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+
+`
+export const CardContentLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+`
+
+export const Description = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  & p {
+    font-size: ${({ theme }) => theme.fontSize.medium};
+  }
+
+  & p:first-child {
+    font-size: ${({ theme }) => theme.fontSize.large};
+    font-weight: ${({ theme }) => theme.fontWeight.bold};
+    margin-bottom: 4px;
+  }
+`
+export const BedgeContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`
+export const CardContentRight = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-align: right;
+
+  & p {
+    font-size: ${({ theme }) => theme.fontSize.medium};
+    font-weight: ${({ theme }) => theme.fontWeight.semi};
+  }
+`

--- a/src/pages/MateDetailPage/index.tsx
+++ b/src/pages/MateDetailPage/index.tsx
@@ -1,0 +1,21 @@
+import { MateDetailPageContainer, MateDetailDescription, MateDetailPhoto, UserInfoListWrapper } from './style'
+import UserInfoList from '@components/UserInfoList'
+import MateDetailCard from './MateDetailCard'
+import MateDetailAction from './MateDetailAction'
+import MateDetailDefaultPhoto from '@assets/default/detail_test.jpg'
+
+const MateDetailPage = () => {
+  return (
+    <MateDetailPageContainer>
+      <MateDetailPhoto src={MateDetailDefaultPhoto} alt='피치메이트 이미지' />
+      <MateDetailCard />
+      <UserInfoListWrapper>
+        <UserInfoList />
+      </UserInfoListWrapper>
+      <MateDetailDescription placeholder='내용을 입력해주세요.'/>
+      <MateDetailAction />
+    </MateDetailPageContainer>
+  )
+}
+
+export default MateDetailPage

--- a/src/pages/MateDetailPage/style.ts
+++ b/src/pages/MateDetailPage/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components'
+
+export const MateDetailPageContainer = styled.div``
+
+export const MateDetailPhoto = styled.img`
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+`
+
+export const MateDetailDescription = styled.textarea`
+  width: calc(100% - 2.5em);
+  height: 100%;
+  border: none;
+  resize: none;
+  padding: 1em;
+  margin: 1em 1.25em;
+`
+  
+export const UserInfoListWrapper = styled.div`
+  padding: 0.5em 1.25em
+`

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,7 @@ import MateListPage from '@pages/MateListPage'
 import SplashPage from '@pages/SplashPage'
 import LoginPage from '@pages/LoginPage'
 import SignupPage from '@pages/LoginPage/SignupPage'
+import MateDetailPage from '@pages/MateDetailPage'
 
 const AppRoutes = () => {
   return (
@@ -48,6 +49,10 @@ const AppRoutes = () => {
         <Route
           path='/chat-room'
           element={<ChatRoom />}
+        />
+        <Route
+          path='/mate-detail'
+          element={<MateDetailPage />}
         />
       </Route>
 


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 메이트 상세 페이지 컴포넌트 구현

## 📝 구현한 내용
![스크린샷 2024-11-27 16 48 34](https://github.com/user-attachments/assets/b8fbd982-0c23-4498-91f7-055e149ec0e3)

- **MateDetailPage** 컴포넌트 작성
  - `MateDetailPageContainer`: 페이지 전체 레이아웃 정의
  - `MateDetailPhoto`: 메이트 상세 사진 표시
  - `MateDetailDescription`: 상세 설명 입력 필드
  - `UserInfoListWrapper`: 유저 정보 리스트 감싸는 래퍼

- **MateDetailAction** 컴포넌트 작성
  - 조건에 따른 경고 메시지 및 액션 버튼 렌더링
  - 참여자 수와 버튼 상태 동적 처리
  - Styled-Components로 액션 영역 스타일링

- **MateDetailCard** 컴포넌트 작성
  - 메이트 정보 및 모집 정보 표시
  - 카드 배지 렌더링 및 카드 레이아웃 구성
  - Styled-Components로 카드 스타일링

- **Styled-Components** 활용
  - 각 컴포넌트에 필요한 세부 스타일 정의
  - 테마(`theme`) 변수를 활용하여 일관된 스타일 적용

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발
- [x] 코드 가독성과 재사용성 고려

## 💬 리뷰 요구 사항
- 레이아웃 및 스타일링 최적화 관련 피드백
- 조건별 버튼 렌더링 로직 검토

## 🔗 연관된 이슈
- close (#57 )
