### PR TITLE
Feat/#56 마이팀 페이지 마크업

### DIFF
--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -1,0 +1,23 @@
+import UpArrow from '@assets/icon/float_up.svg?react';
+import { ScrollButton } from './style';
+
+const ScrollToTopButton = () => {
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+    console.log('페이지 상단으로 이동');
+  };
+
+  return (
+    <ScrollButton
+      onClick={scrollToTop}
+      aria-label="페이지 상단으로 이동"
+    >
+      <UpArrow />
+    </ScrollButton>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/components/ScrollToTopButton/style.ts
+++ b/src/components/ScrollToTopButton/style.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const ScrollButton = styled.button`
+  position: fixed;
+  bottom: 80px; 
+  left: 40px; 
+  width: 50px;
+  height: 50px;
+  background-color: ${theme.fontColor.white}91;
+  border: none;
+  border-radius: 50%;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  z-index: 1000;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+
+  &:hover {
+    transform: scale(1.1);
+    background-color: ${theme.fontColor.white};
+  }
+
+  svg {
+    width: 24px;
+    height: 24px;
+    fill: #002561; /* 화살표 색상 (팀 컬러 적용 가능) */
+    opacity: 0.57;
+  }
+
+  &:hover svg {
+    opacity: 1;
+  }
+`;

--- a/src/pages/MyTeamPage/GoodsCardSection/index.tsx
+++ b/src/pages/MyTeamPage/GoodsCardSection/index.tsx
@@ -1,0 +1,24 @@
+import GoodsCard from '@components/GoodsCard'
+import { GoodsCardContainer, CardWrapper } from './style'
+import { kboTeamInfo } from '@utils/kboInfo'
+import { useNavigate } from 'react-router-dom'
+
+const GoodsCardSection = () => {
+  const navigate = useNavigate()
+  return (
+    <GoodsCardContainer>
+      <h3>{`${kboTeamInfo.삼성.team} 상품 찾기`}</h3>
+      <CardWrapper>
+        <GoodsCard />
+        <GoodsCard />
+        <GoodsCard />
+        <GoodsCard />
+      </CardWrapper>
+      <p className='more' onClick={() => navigate('/')}>
+        더보기
+      </p>
+    </GoodsCardContainer>
+  )
+}
+
+export default GoodsCardSection

--- a/src/pages/MyTeamPage/GoodsCardSection/style.ts
+++ b/src/pages/MyTeamPage/GoodsCardSection/style.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const GoodsCardContainer = styled.div`
+  width: 100%;
+  padding: 1em 1.25em;
+
+  h3 {
+    padding: 1em 0;
+  }
+
+  .more {
+    padding: 1em 1.25em;
+    font-size: ${theme.fontSize.large};
+    font-weight: ${theme.fontWeight.regular};
+    text-align: center;
+    cursor: pointer;
+    color: ${theme.fontColor.black};
+  }
+`
+export const CardWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px; /* 카드 간격 */
+  justify-content: space-between;
+
+  & > * {
+    flex: 1 1 calc(50% - 10px); /* 2열을 유지하면서 카드 크기 맞춤 */
+    max-width: calc(50% - 10px); /* 최대 너비 제한 */
+  }
+`

--- a/src/pages/MyTeamPage/MatchUpSection/index.tsx
+++ b/src/pages/MyTeamPage/MatchUpSection/index.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+// import { Pagination } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+import {
+  GameDatetimeLocation,
+  TeamVersus,
+  LocationWeather,
+  UpdateInfo,
+  Weather,
+  MatchUpContainer,
+//   PaginationContainer, 
+} from './style';
+import { kboTeamInfo } from '@utils/kboInfo';
+
+const matchData = [
+  {
+    homeTeam: '삼성',
+    awayTeam: 'LG',
+    gameDateTime: '11월 26일 18시 30분',
+    location: '대구 삼성 라이온즈 파크',
+    weather: '구름 많음 10°C',
+    lastUpdated: '15시',
+  }
+];
+
+const MatchUpSection = () => {
+  return (
+    <>
+      <Swiper
+        spaceBetween={0}
+        slidesPerView={1}
+        // pagination={{
+        //   el: '.custom-pagination', 
+        //   clickable: true,
+        // }}
+        // modules={[Pagination]}
+      >
+        {matchData.map((match, index) => {
+          const homeTeamColor = kboTeamInfo[match.homeTeam].color;
+          const awayTeamColor = kboTeamInfo[match.awayTeam].color;
+
+          return (
+            <SwiperSlide key={index}>
+              <MatchUpContainer
+                homeColor={homeTeamColor}
+                awayColor={awayTeamColor}
+              >
+                <GameDatetimeLocation>
+                  <span>
+                    {match.gameDateTime} - {match.location}
+                  </span>
+                </GameDatetimeLocation>
+                <TeamVersus>
+                  <div>
+                    {React.createElement(kboTeamInfo[match.homeTeam].logo)}
+                  </div>
+                  <span>vs</span>
+                  <div>
+                    {React.createElement(kboTeamInfo[match.awayTeam].logo)}
+                  </div>
+                </TeamVersus>
+                <LocationWeather>
+                  <UpdateInfo>
+                    {match.location}({match.lastUpdated} 기준)
+                  </UpdateInfo>
+                  <Weather>{match.weather}</Weather>
+                </LocationWeather>
+              </MatchUpContainer>
+            </SwiperSlide>
+          );
+        })}
+      </Swiper>
+      {/* <PaginationContainer className="custom-pagination" />  */}
+    </>
+  );
+};
+
+export default MatchUpSection;

--- a/src/pages/MyTeamPage/MatchUpSection/style.ts
+++ b/src/pages/MyTeamPage/MatchUpSection/style.ts
@@ -1,0 +1,88 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const MatchUpContainer = styled.div<{
+  homeColor: string
+  awayColor: string
+}>`
+  padding: 1.25em;
+  background: ${({ homeColor, awayColor }) =>
+    `linear-gradient(90deg, ${homeColor} 0%, ${awayColor} 100%)`};
+  color: ${theme.fontColor.white}; /* 텍스트가 잘 보이도록 설정 */
+`
+
+// export const PaginationContainer = styled.div`
+//   margin-top: 10px; /* 배경 아래로 간격 추가 */
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+
+//   .swiper-pagination-bullet {
+//     width: 6px;
+//     height: 6px;
+//     background: #d9d9d9; /* 기본 색상 */
+//     opacity: 0.7;
+//     margin: 0 5px;
+//   }
+
+//   .swiper-pagination-bullet-active {
+//     background: ${theme.fontColor.navy}; /* 활성화된 색상 */
+//     opacity: 1;
+//   }
+// `;
+
+export const GameDatetimeLocation = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+  font-size: ${theme.fontSize.medium};
+  color: ${theme.fontColor.white};
+`
+
+export const TeamVersus = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  font-size: 18px;
+  font-weight: ${theme.fontWeight.bold};
+
+  & > div {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+  }
+
+  & > div > svg {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  span {
+    font-size: ${theme.fontSize.xlarge};
+  }
+`
+
+export const LocationWeather = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1em;
+  font-size: ${theme.fontSize.medium};
+`
+
+export const UpdateInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${theme.fontColor.white};
+`
+
+export const Weather = styled.div`
+  font-size: ${theme.fontSize.medium};
+  color: ${theme.fontColor.white};
+`

--- a/src/pages/MyTeamPage/MateCardSection/index.tsx
+++ b/src/pages/MyTeamPage/MateCardSection/index.tsx
@@ -1,0 +1,21 @@
+import MateCard from '@components/MateCard'
+import { kboTeamInfo } from '@utils/kboInfo'
+import { MateCardContainer } from './style'
+import { useNavigate } from 'react-router-dom'
+
+const MateCardSection = () => {
+  const navigate = useNavigate()
+  return (
+    <MateCardContainer>
+      <h3>{`${kboTeamInfo.삼성.team} 메이트 찾기`}</h3>
+      <MateCard />
+      <MateCard />
+      <MateCard />
+      <p className='more' onClick={() => navigate('/')}>
+        더보기
+      </p>
+    </MateCardContainer>
+  )
+}
+
+export default MateCardSection

--- a/src/pages/MyTeamPage/MateCardSection/style.ts
+++ b/src/pages/MyTeamPage/MateCardSection/style.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const MoreSection = styled.div`
+  display: flex;
+  justify-content: center;
+`
+export const MateCardContainer = styled.div`
+  h3 {
+    padding: 1em 1.25em;
+  }
+
+  .more {
+    padding: 1em 1.25em;
+    font-size: ${theme.fontSize.large};
+    font-weight: ${theme.fontWeight.regular};
+    text-align: center;
+    cursor: pointer;
+    color: ${theme.fontColor.black};
+  }
+`

--- a/src/pages/MyTeamPage/ResultSection/ResultList/index.tsx
+++ b/src/pages/MyTeamPage/ResultSection/ResultList/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { ResultListTable, RivalTeam, ResultListTitle } from './style'
+import { kboTeamInfo } from '@utils/kboInfo'
+
+const ResultList = () => {
+  const gameResults = [
+    { date: '10/28', rival: 'LG', result: '승', score: '71-10' },
+    { date: '10/21', rival: '롯데', result: '패', score: '7-8' },
+    { date: '10/11', rival: 'LG', result: '패', score: '7-8' },
+    { date: '99/99', rival: 'LG', result: '무', score: '7-7' },
+    { date: '99/99', rival: 'LG', result: '무', score: '7-7' },
+    { date: '99/99', rival: 'LG', result: '무', score: '7-7' },
+  ]
+
+  return (
+    <div>
+      <ResultListTitle>삼성 라이온즈의 최근 전적</ResultListTitle>
+      <ResultListTable>
+        <thead>
+        <tr>
+          <th>날짜</th>
+          <th>vs</th>
+          <th>상대 팀</th>
+          <th>결과</th>
+          <th>점수</th>
+        </tr>
+      </thead>
+      <tbody>
+        {gameResults.map((game, index) => {
+          const teamInfo = kboTeamInfo[game.rival] // 팀 정보 가져오기
+          return (
+            <tr key={index}>
+              <td className='date'>{game.date}</td>
+              <td className='vs'>vs</td>
+              <td className='rival-team'>
+                <RivalTeam>
+                  <teamInfo.logo className='team-logo' /> {/* 팀 로고 */}
+                  <span className='team-name'>{teamInfo.team}</span>
+                </RivalTeam>
+              </td>
+              <td
+                className={`result ${
+                  game.result === '승'
+                    ? 'win'
+                    : game.result === '패'
+                      ? 'loss'
+                      : 'draw'
+                }`}
+              >
+                {game.result}
+              </td>
+              <td>{game.score}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+      </ResultListTable>
+    </div>
+  )
+}
+
+export default ResultList

--- a/src/pages/MyTeamPage/ResultSection/ResultList/style.ts
+++ b/src/pages/MyTeamPage/ResultSection/ResultList/style.ts
@@ -1,0 +1,80 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+
+export const ResultListTitle = styled.h3`
+  font-size: 20px;
+  font-weight: ${theme.fontWeight.medium};
+  margin-bottom: 20px;
+  color: ${theme.fontColor.black};
+  `
+
+export const ResultListTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  color: ${theme.fontColor.black};
+  margin-bottom: 20px;
+
+  thead {
+    display: none;
+  }
+
+  tbody {
+    border-top: 1px solid ${theme.fontColor.cwhite};
+  }
+
+  th,
+  td {
+    padding: 10px;
+    text-align: center;
+    border-bottom: 1px solid ${theme.fontColor.cwhite};
+  }
+
+
+  tr:hover {
+    background-color: ${theme.fontColor.cwhite};
+  }
+
+  .date {
+    text-align: left;
+  }
+
+  .vs {
+    width: 100px;
+  }
+
+  .team-name {
+    font-weight: ${theme.fontWeight.medium};
+  }
+
+  .result {
+    font-weight: ${theme.fontWeight.bold};
+  }
+
+  .win {
+    color: #00c073;
+  }
+
+  .loss {
+    color: #e7252e;
+  }
+
+  .draw {
+    color: ${theme.fontColor.black};
+  }
+`;
+
+export const RivalTeam = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  .team-logo {
+    width: 30px;
+    height: 30px;
+  }
+
+  span {
+    font-size: 14px;
+    font-weight: bold;
+  }
+`;

--- a/src/pages/MyTeamPage/ResultSection/ResultSummary/index.tsx
+++ b/src/pages/MyTeamPage/ResultSection/ResultSummary/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ResultSummaryContainer, TeamInfo, GameStats } from './style';
+import { kboTeamInfo } from '@utils/kboInfo';
+
+interface ResultSummaryProps {
+  teamKey: string; // 팀 이름 키
+}
+
+const ResultSummary: React.FC<ResultSummaryProps> = ({ teamKey }) => {
+  const teamInfo = kboTeamInfo[teamKey]; // 팀 정보 가져오기
+
+  return (
+    <ResultSummaryContainer teamKey={teamKey}>
+      <TeamInfo>
+        <teamInfo.logo className="logo" /> {/* 팀 로고 */}
+        <div className="team-name">{teamInfo.team}</div>
+      </TeamInfo>
+      <GameStats>
+        <span className="total-games">144 / 144 경기</span>
+        <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+        <span className="win-draw-loss">61 승 2무 81패</span>
+      </GameStats>
+    </ResultSummaryContainer>
+  );
+};
+
+export default ResultSummary;

--- a/src/pages/MyTeamPage/ResultSection/ResultSummary/style.ts
+++ b/src/pages/MyTeamPage/ResultSection/ResultSummary/style.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components'
+import { theme } from '@styles/theme'
+import { kboTeamInfo } from '@utils/kboInfo'
+
+interface ResultSummaryContainerProps {
+  teamKey: string // 팀 이름 키
+}
+
+export const ResultSummaryContainer = styled.div<ResultSummaryContainerProps>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  background-color: ${({ teamKey }) =>
+    kboTeamInfo[teamKey]?.color ||
+    '#004aad'}; /* 팀 색상 적용 (기본값: 파란색) */
+  padding: 8px 20px;
+  color: ${theme.fontColor.white};
+`
+
+export const TeamInfo = styled.div`
+  display: flex;
+  align-items: center;
+
+  .logo {
+    width: 20px;
+    height: 20px;
+    margin-right: 10px;
+  }
+
+  .team-name {
+    font-size: ${theme.fontSize.small};
+    font-weight: ${theme.fontWeight.regular};
+  }
+`
+
+export const GameStats = styled.div`
+  text-align: right;
+  font-size: ${theme.fontSize.small};
+  font-weight: ${theme.fontWeight.regular};
+
+  .win-draw-loss {
+    margin-top: 5px;
+  }
+`

--- a/src/pages/MyTeamPage/ResultSection/index.tsx
+++ b/src/pages/MyTeamPage/ResultSection/index.tsx
@@ -1,0 +1,14 @@
+import { ResultSectionContainer } from './style'
+import ResultSummary from './ResultSummary'
+import ResultList from './ResultList'
+
+const ResultSection = () => {
+  return (
+    <ResultSectionContainer>
+      <ResultSummary teamKey='삼성' />
+      <ResultList />
+    </ResultSectionContainer>
+  )
+}
+
+export default ResultSection

--- a/src/pages/MyTeamPage/ResultSection/style.ts
+++ b/src/pages/MyTeamPage/ResultSection/style.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components'
+
+export const ResultSectionContainer = styled.div``

--- a/src/pages/MyTeamPage/index.tsx
+++ b/src/pages/MyTeamPage/index.tsx
@@ -1,0 +1,24 @@
+import { MyTeamPageContainer, TeamSelectWrapper } from './style'
+import TeamSelectSection from '@components/TeamSelectSection'
+import MatchUpSection from './MatchUpSection'
+import MateCardSection from './MateCardSection'
+import GoodsCardSection from './GoodsCardSection'
+import ResultSection from './ResultSection'
+import ScrollToTopButton from '@components/ScrollToTopButton'
+
+const MyTeamPage = () => {
+  return (
+    <MyTeamPageContainer>
+      <MatchUpSection />
+      <TeamSelectWrapper>
+        <TeamSelectSection />
+      </TeamSelectWrapper>
+      <MateCardSection />
+      <GoodsCardSection />
+      <ResultSection />
+      <ScrollToTopButton />
+    </MyTeamPageContainer>
+  )
+}
+
+export default MyTeamPage

--- a/src/pages/MyTeamPage/style.ts
+++ b/src/pages/MyTeamPage/style.ts
@@ -2,4 +2,6 @@ import styled from 'styled-components'
 
 export const MyTeamPageContainer = styled.div``
 
-export const TeamSelectWrapper = styled.div``
+export const TeamSelectWrapper = styled.div`
+  padding: 16px 0 16px 20px;
+`

--- a/src/pages/MyTeamPage/style.ts
+++ b/src/pages/MyTeamPage/style.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components'
+
+export const MyTeamPageContainer = styled.div``
+
+export const TeamSelectWrapper = styled.div``

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,6 +12,7 @@ import MateListPage from '@pages/MateListPage'
 import SplashPage from '@pages/SplashPage'
 import LoginPage from '@pages/LoginPage'
 import SignupPage from '@pages/LoginPage/SignupPage'
+import MyTeamPage from '@pages/MyTeamPage'
 
 const AppRoutes = () => {
   return (
@@ -33,6 +34,10 @@ const AppRoutes = () => {
         <Route
           path='/login/signup'
           element={<SignupPage />}
+        />
+        <Route
+          path='/myteam'
+          element={<MyTeamPage />}
         />
       </Route>
 

--- a/src/utils/kboInfo.tsx
+++ b/src/utils/kboInfo.tsx
@@ -14,6 +14,7 @@ interface KboTeamInfo {
   [key: string]: {
     team: string
     logo: React.VFC<React.SVGProps<SVGSVGElement>>
+    color: string // 팀 대표 색상 추가
   }
 }
 
@@ -21,46 +22,57 @@ const kboTeamInfo: KboTeamInfo = {
   전체: {
     team: 'KBO',
     logo: KBO,
+    color: '#002561',
   },
   두산: {
     team: '두산 베어스',
     logo: Doosan,
+    color: '#131230',
   },
   롯데: {
     team: '롯데 자이언츠',
     logo: Lotte,
+    color: '#041E42',
   },
   삼성: {
     team: '삼성 라이온즈',
     logo: Samsung,
+    color: '#074CA1',
   },
   키움: {
     team: '키움 히어로즈',
     logo: Kiwoom,
+    color: '#570514',
   },
   한화: {
     team: '한화 이글스',
     logo: Hanwha,
+    color: '#FF6600',
   },
   KIA: {
     team: 'KIA 타이거즈',
     logo: Kia,
+    color: '#EA0029',
   },
   KT: {
     team: 'KT 위즈',
     logo: KT,
+    color: '#000000',
   },
   LG: {
     team: 'LG 트윈스',
     logo: LG,
+    color: '#C30452',
   },
   NC: {
     team: 'NC 다이노스',
     logo: NC,
+    color: '#315288',
   },
   SSG: {
     team: 'SSG 랜더스',
     logo: SSG,
+    color: '#CE0E2D',
   },
 }
 


### PR DESCRIPTION
## 🛠️ 구현한 기능
- `MyTeamPage` 컴포넌트 구현
- 페이지 하단에 "상단으로 이동" 버튼 추가
- 페이지 레이아웃 및 섹션 구성

## 📝 구현한 내용
![스크린샷 2024-11-27 18 04 25](https://github.com/user-attachments/assets/d129fbf8-bd7a-4dac-aac3-699fe026738d)

- **`MyTeamPage` 구성**:
  - `MatchUpSection`: 매칭 관련 섹션 추가
  - `TeamSelectSection`: 팀 선택 섹션 추가
  - `MateCardSection`: 친구(메이트) 카드 섹션 추가
  - `GoodsCardSection`: 굿즈 카드 섹션 추가
  - `ResultSection`: 경기 결과 섹션 추가
- ~~**`ScrollToTopButton` 컴포넌트**:~~
  - ~~버튼 클릭 시 페이지 상단으로 스크롤 이동~~

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발 완료
- [x] UI와 동작 확인 완료

## 💬 리뷰 요구 사항
- `MyTeamPage`의 섹션 구성과 컴포넌트 구조에 대한 의견
- ~~`ScrollToTopButton`의 위치 및 동작 테스트~~

## 🔗 연관된 이슈
- close (#56 )
