### PR TITLE
Feat/#69 네이버 로그인 

### DIFF
--- a/src/pages/LoginPage/AuthCallback/RedirectHandler.tsx
+++ b/src/pages/LoginPage/AuthCallback/RedirectHandler.tsx
@@ -1,0 +1,40 @@
+// 서버 연결 전 목업 서버 요청 테스트
+
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+const RedirectHandler = () => {
+  const [searchParams] = useSearchParams()
+
+  useEffect(() => {
+    // URL에서 code와 state 값 추출
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+
+    if (code && state) {
+      console.log('✅ 네이버 로그인 성공')
+      console.log('Code:', code)
+      console.log('State:', state)
+
+      // Mock 서버 요청 (실제 서버 요청은 백엔드 연동 후 추가)
+      mockSendCodeToBackend(code, state)
+    } else {
+      console.error('❌ code 또는 state 값이 없습니다.')
+    }
+  }, [searchParams])
+
+  return <div>로그인 처리 중...</div>
+}
+
+// Mock 서버 요청
+const mockSendCodeToBackend = (code: string, state: string) => {
+  console.log('📤 서버로 전달할 데이터:', { code, state })
+
+  const mockResponse = {
+    success: true,
+    message: 'Mock response - 백엔드 없이 테스트 완료',
+  }
+  console.log('📥 서버 응답:', mockResponse)
+}
+
+export default RedirectHandler

--- a/src/pages/LoginPage/AuthCallback/RedirectHandlerOld.tsx
+++ b/src/pages/LoginPage/AuthCallback/RedirectHandlerOld.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+const RedirectHandler = () => {
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
+
+    if (code && state) {
+      console.log("Code:", code);
+      console.log("State:", state);
+
+      // 백엔드로 전달
+      sendCodeToBackend(code, state);
+    } else {
+      console.error("Code 또는 State가 없습니다.");
+    }
+  }, [searchParams]);
+
+  return <div>로그인 처리 중...</div>;
+};
+
+const sendCodeToBackend = async (code: string, state: string) => {
+  try {
+    const response = await fetch("/api/auth/naver", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code, state }),
+    });
+    const data = await response.json();
+    console.log("Backend Response:", data);
+  } catch (error) {
+    console.error("Error sending code to backend:", error);
+  }
+};
+
+export default RedirectHandler;

--- a/src/pages/LoginPage/NaverLoginButton/index.tsx
+++ b/src/pages/LoginPage/NaverLoginButton/index.tsx
@@ -1,16 +1,33 @@
 import { StyledButton } from './style'
 import NaverButton from '@assets/icon/naver_login.png'
-import { useNavigate } from 'react-router-dom'
+
+// UUID 생성 함수: CSRF 방지를 위한 고유 state 값 생성
+const generateUUID = (): string => {
+  return ([1e7] as any + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c: string) =>
+    (
+      parseInt(c, 10) ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (parseInt(c, 10) / 4)))
+    ).toString(16)
+  )
+}
 
 const NaverLoginButton = () => {
-  const navigate = useNavigate()
+  // 환경 변수 가져오기
+  const CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID
+  const REDIRECT_URI = encodeURIComponent(import.meta.env.VITE_REDIRECT_URI as string)
+  const STATE = generateUUID()
+
+  // 네이버 로그인 인증 URL 생성
+  const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&state=${STATE}`
+
+  // 로그인 버튼 클릭 핸들러
+  const handleLoginClick = () => {
+    window.location.href = NAVER_AUTH_URL
+  }
 
   return (
-    <StyledButton onClick={() => navigate('/login/signup')}>
-      <img
-        src={NaverButton}
-        alt='네이버 로그인'
-      />
+    <StyledButton onClick={handleLoginClick}>
+      <img src={NaverButton} alt="네이버 로그인" />
     </StyledButton>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,6 +23,7 @@ import ProfileMain from '@pages/ProfilePage/ProfileMain'
 import ProfileEdit from '@pages/ProfilePage/ProfileEdit'
 import ReviewPage from '@pages/ProfilePage/ReviewPage'
 import TimelinePage from '@pages/TimelinePage'
+import RedirectHandler from '@pages/LoginPage/AuthCallback/RedirectHandler'
 
 const AppRoutes = () => {
   return (
@@ -124,6 +125,11 @@ const AppRoutes = () => {
       <Route
         path='/notification'
         element={<NotificationPage />}
+      />
+
+      <Route
+        path='/api/auth/login/naver'
+        element={<RedirectHandler />}
       />
     </Routes>
   )


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 네이버 로그인 리다이렉트 핸들러(`RedirectHandler`) 구현
- URL 쿼리 파라미터(`code`, `state`) 처리 로직 추가
- 네이버 로그인 콜백 URI(`/api/auth/login/naver`)와 연동
- Mock 서버 요청으로 백엔드 없는 상태에서도 동작 테스트 가능

## 📝 구현한 내용
- `useSearchParams`를 사용하여 네이버 로그인 인증 성공 시 전달되는 `code`와 `state`를 추출
- 추출된 데이터를 `MockSendCodeToBackend` 함수를 통해 로그 출력 및 시뮬레이션 처리
- 에러 처리 로직 추가: 쿼리 파라미터 누락 시 콘솔에 에러 메시지 출력
- Vite 환경 변수(`VITE_NAVER_CLIENT_ID`, `VITE_REDIRECT_URI`)를 활용하여 로그인 동작 설정

![스크린샷 2024-11-28 16 17 20](https://github.com/user-attachments/assets/68a0fa3d-0e6f-4d11-a615-5ad3b384a382)
![스크린샷 2024-11-28 16 16 42](https://github.com/user-attachments/assets/466a0b47-4b8e-4b53-b8e5-3a3d36016b5d)

## ✅ 체크리스트
- [x] 환경 변수(`VITE_NAVER_CLIENT_ID`, `VITE_REDIRECT_URI`) 설정 확인
- [x] 네이버 개발자 센터에서 콜백 URI 설정 확인
- [x] Mock 처리로 백엔드 연동 없이 동작 확인
- [x] Vite 개발 서버에서 테스트 완료

## 💬 리뷰 요구 사항
- 네이버 로그인 리다이렉트 핸들러에서 추가해야 할 예외 처리나 개선 사항

## 🔗 연관된 이슈
- close #69 

