### PR TITLE
🐛 Fix : 리뷰 페이지 카테고리 버튼 비동기 이슈 처리 #85

### DIFF
--- a/src/pages/ProfilePage/ReviewPage.tsx
+++ b/src/pages/ProfilePage/ReviewPage.tsx
@@ -16,14 +16,10 @@ interface ReviewTypes {
 }
 
 const ReviewPage = () => {
-  const [selectedButton, setSelectedButton] = useState('mate')
+  const [selectedButton, setSelectedButton] = useState('1')
   const [reviewDataList, setReviewDataList] = useState<ReviewTypes[] | null>(
     null,
   )
-
-  const onSelectButton = (id: string) => {
-    setSelectedButton(id)
-  }
 
   const decideRatingText = (rating: string) => {
     switch (rating) {
@@ -37,9 +33,9 @@ const ReviewPage = () => {
   }
 
   useEffect(() => {
-    if (selectedButton === 'mate') {
+    if (selectedButton === '2') {
       setReviewDataList(mateReviewList)
-    } else if (selectedButton === 'goods') {
+    } else if (selectedButton === '1') {
       setReviewDataList(goodsReviewList)
     }
   }, [selectedButton])
@@ -49,12 +45,12 @@ const ReviewPage = () => {
       <ReviewButtonWrap>
         <PillButtonList
           buttons={[
-            { id: 'goods', text: '굿즈거래 후기', disabled: false },
-            { id: 'mate', text: '메이트 후기', disabled: false },
+            { id: '1', text: '굿즈거래 후기', disabled: false },
+            { id: '2', text: '메이트 후기', disabled: false },
           ]}
           mode='radio'
-          defaultSelected='goods'
-          onSelect={onSelectButton}
+          defaultSelected={selectedButton}
+          onSelect={(id) => setSelectedButton(id)}
         />
       </ReviewButtonWrap>
       <ReviewWrap>
@@ -65,14 +61,14 @@ const ReviewPage = () => {
                 <span>{decideRatingText(data.rating)}</span>
                 <p>{data.review_content}</p>
                 <em>
-                  ㅎ{data.reviewer_name} · {useFormattingDate(data.createdAt)}
+                  {data.reviewer_name} · {useFormattingDate(data.createdAt)}
                 </em>
                 <ReviewLinkBox>
                   <Link to={'/'}>
                     <div>
                       <span>
-                        {selectedButton === 'mate' && '직관후기'}
-                        {selectedButton === 'goods' && '굿즈거래'}
+                        {selectedButton === '2' && '직관후기'}
+                        {selectedButton === '1' && '굿즈거래'}
                       </span>
                       <i>쁘띠 이대호 피규어 & 쁘띠 이대호 빠따</i>
                     </div>

--- a/src/pages/ProfilePage/ReviewPage.tsx
+++ b/src/pages/ProfilePage/ReviewPage.tsx
@@ -16,7 +16,10 @@ interface ReviewTypes {
 }
 
 const ReviewPage = () => {
-  const [selectedButton, setSelectedButton] = useState('1')
+  const GOODS_REVIEW = '1';
+  const MATE_REVIEW = '2';
+  
+  const [selectedButton, setSelectedButton] = useState(GOODS_REVIEW)
   const [reviewDataList, setReviewDataList] = useState<ReviewTypes[] | null>(
     null,
   )


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 리뷰 페이지 카테고리 버튼 비동기 이슈 처리

## 📝 구현한 내용
- 버튼 id값 string형식의 숫자로 변경
- default select 설정

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- close (#85 )
