### PR TITLE
GD / 긋즈 디테일 페이지 수정사항반영 & 기타 수정사항

### DIFF
--- a/src/assets/icon/back.svg
+++ b/src/assets/icon/back.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14 18L8 12L14 6L15.4 7.4L10.8 12L15.4 16.6L14 18Z" fill="#2B2E33"/>
+<svg width="8" height="12" viewBox="0 0 8 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 12L0 6L6 0L7.4 1.4L2.8 6L7.4 10.6L6 12Z" fill="#2B2E33"/>
 </svg>

--- a/src/components/CardBedge/index.tsx
+++ b/src/components/CardBedge/index.tsx
@@ -1,10 +1,21 @@
+import { useEffect, useState } from 'react'
 import { Bedge } from './style'
 import { kboTeamInfo } from '@constants/kboInfo'
 
 const CardBedge = ({ text }: { text?: string }) => {
-  const teamColor =
-    text && kboTeamInfo[text] ? kboTeamInfo[text].color : undefined
-  return <Bedge $bgcolor={teamColor}>{text || '벳지'}</Bedge>
+  const [bgColor, setBgColor] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (text !== '거래완료') {
+      text && kboTeamInfo[text]
+        ? setBgColor(kboTeamInfo[text].color)
+        : undefined
+    } else {
+      setBgColor('#D9D9D9')
+    }
+  }, [])
+
+  return <Bedge $bgcolor={bgColor}>{text || '벳지'}</Bedge>
 }
 
 export default CardBedge

--- a/src/components/UserInfoList/index.tsx
+++ b/src/components/UserInfoList/index.tsx
@@ -1,6 +1,6 @@
-import FuckingBat from '@assets/icon/baseball.svg?react'
+import BatIcon from '@assets/icon/baseball.svg?react'
 
-import { DescriptionContainer, ProfileContainer } from './style'
+import { DescriptionContainer, ProfileContainer, ProfileManner } from './style'
 import ProfileBedge from '@components/ProfileBedge'
 import { GoodsDetail } from '@typings/db'
 
@@ -20,8 +20,8 @@ const UserInfoList = ({ seller }: { seller: GoodsDetail['seller'] }) => {
         <p>{nickname}</p>
       </ProfileContainer>
       <p>
-        {manner}
-        <FuckingBat />
+        <ProfileManner>{manner}</ProfileManner>
+        <BatIcon />
       </p>
     </DescriptionContainer>
   )

--- a/src/components/UserInfoList/style.ts
+++ b/src/components/UserInfoList/style.ts
@@ -22,3 +22,7 @@ export const ProfileContainer = styled.div`
 
   font-weight: ${({ theme }) => theme.fontWeight.medium};
 `
+
+export const ProfileManner = styled.span`
+  color: ${({ theme }) => theme.fontColor.navy};
+`

--- a/src/layouts/SubHeader/index.tsx
+++ b/src/layouts/SubHeader/index.tsx
@@ -30,7 +30,7 @@ const SubHeader = ({ left, center, right, onClick }: SubHeaderPropsType) => {
 
   const subHeaderLeftContent = {
     back: <Back onClick={handleClick} />,
-    exit: <Exit />,
+    exit: <Exit onClick={handleClick} />,
     message: <SubHeaderMessageText>메시지</SubHeaderMessageText>,
   }
 

--- a/src/pages/GoodsDetailPage/KakaoMapContainer/index.tsx
+++ b/src/pages/GoodsDetailPage/KakaoMapContainer/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Map, MapMarker } from 'react-kakao-maps-sdk'
+
+const KakaoMapContainer = ({
+  latitude,
+  longitude,
+}: {
+  latitude: string
+  longitude: string
+}) => {
+  const handleMapClick = () => {
+    const kakaoMapUrl = `https://map.kakao.com/?q=${latitude},${longitude}`
+    window.open(kakaoMapUrl, '_blank')
+  }
+
+  return (
+    <Map
+      center={{
+        lat: Number(latitude),
+        lng: Number(longitude),
+      }}
+      style={{ width: '100%', height: '115px' }}
+      draggable={false}
+      onClick={handleMapClick}
+    >
+      <MapMarker
+        position={{
+          lat: Number(latitude),
+          lng: Number(longitude),
+        }}
+        onClick={handleMapClick}
+      />
+    </Map>
+  )
+}
+
+export default KakaoMapContainer

--- a/src/pages/GoodsDetailPage/index.tsx
+++ b/src/pages/GoodsDetailPage/index.tsx
@@ -9,6 +9,7 @@ import {
   GoodsDetailMapWrap,
   GoodsDetailText,
   GoodsDetailTop,
+  GoodsDetailWrap,
   GoodsNoticeWrap,
   GoodsPriceText,
   PaginationContainer,
@@ -37,6 +38,7 @@ import Alert from '@components/Alert'
 import ALERT_MESSAGE from '@constants/alertMessage'
 import { useModal } from '@hooks/useModal'
 import goodsChatService from '@apis/goodsChatService'
+import KakaoMapContainer from './KakaoMapContainer'
 
 const GoodsDetailPage = () => {
   const [isOwner, setIsOwner] = useState(false)
@@ -50,6 +52,8 @@ const GoodsDetailPage = () => {
     queryFn: () => goodsService.getGoodsDetail(goodsId as string),
     enabled: !!goodsId,
   })
+
+  console.log(data)
 
   // 굿즈 게시글 삭제 요청
   const {
@@ -130,7 +134,7 @@ const GoodsDetailPage = () => {
   } = data
 
   return (
-    <>
+    <GoodsDetailWrap>
       <SubHeader
         left='back'
         center='굿즈 거래하기'
@@ -176,26 +180,11 @@ const GoodsDetailPage = () => {
             <h2>거래 장소</h2>
             <p>{location.placeName}</p>
             <GoodsDetailMapInner>
-              <Map
-                center={{
-                  lat: Number(location.latitude),
-                  lng: Number(location.longitude),
-                }}
-                style={{ width: '100%', height: '115px' }}
-              >
-                <MapMarker
-                  position={{
-                    lat: Number(location.latitude),
-                    lng: Number(location.longitude),
-                  }}
-                />
-              </Map>
-            </GoodsDetailMapInner>{' '}
-            {data.status === '거래중' ? (
-              <CardBedge text='거래중' />
-            ) : (
-              <CardBedge text='거래완료' />
-            )}
+              <KakaoMapContainer
+                latitude={location.latitude}
+                longitude={location.longitude}
+              />
+            </GoodsDetailMapInner>
           </GoodsDetailMapWrap>
         </GoodsNoticeWrap>
 
@@ -244,7 +233,7 @@ const GoodsDetailPage = () => {
           handleAlertClick={handleDeleteGoodsPost}
         />
       </section>
-    </>
+    </GoodsDetailWrap>
   )
 }
 

--- a/src/pages/GoodsDetailPage/style.ts
+++ b/src/pages/GoodsDetailPage/style.ts
@@ -5,6 +5,14 @@ interface ButtonPropTypes {
   $isNavy: boolean
 }
 
+export const GoodsDetailWrap = styled.section`
+  padding: 0 0 75px;
+
+  @media all and (max-width: 431px) {
+    padding: 0 0 65px;
+  }
+`
+
 export const SwiperContainer = styled.div`
   position: relative;
 `
@@ -131,7 +139,7 @@ export const GoodsNoticeWrap = styled.div`
 
 export const GoodsDetailText = styled.div`
   width: 100%;
-  max-height: 190px;
+  min-height: 190px;
   overflow-y: scroll;
   padding: 1em;
   background-color: ${theme.fontColor.cwhite};

--- a/src/pages/ProfilePage/BottomModalOption/index.tsx
+++ b/src/pages/ProfilePage/BottomModalOption/index.tsx
@@ -7,10 +7,12 @@ interface BottomModalOptionProps {
 }
 
 const BottomModalOption = ({ onSelectTeam }: BottomModalOptionProps) => {
+  const { setTeamId } = useGoodsFormStore()
   const [_, ...restTeamList] = kboTeamList
 
   const handleSelectTeam = (team: string, id: number) => {
     onSelectTeam(team, id)
+    setTeamId(id)
   }
 
   return (

--- a/src/pages/ProfilePage/BottomModalOption/index.tsx
+++ b/src/pages/ProfilePage/BottomModalOption/index.tsx
@@ -10,12 +10,9 @@ const BottomModalOption = ({ onSelectTeam }: BottomModalOptionProps) => {
   const { setTeamId } = useGoodsFormStore()
   const [_, ...restTeamList] = kboTeamList
 
-  const { setTeamId } = useGoodsFormStore()
-
   const handleSelectTeam = (team: string, id: number) => {
     setTeamId(id)
     onSelectTeam(team, id)
-    setTeamId(id)
   }
 
   return (

--- a/src/pages/ProfilePage/ProfileEdit.tsx
+++ b/src/pages/ProfilePage/ProfileEdit.tsx
@@ -98,7 +98,7 @@ const ProfileEdit = () => {
       <form onSubmit={onProfileEditSubmit}>
         {/* 서브헤더 */}
         <SubHeader
-          left='back'
+          left='exit'
           center='프로필 수정 페이지'
           right='complete'
         />

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -66,6 +66,7 @@ const ProfileMain = () => {
       <SubHeader
         left='back'
         center='프로필 페이지'
+        right='logout'
       />
       <section>
         {/* 프로필 상단 섹션 */}


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 긋즈 디테일 페이지 수정사항반영 & 기타 수정사항

## 📝 구현한 내용
- [x] 굿즈 디테일 페이지에서 굿즈거래 상태 판매완료시 벳지 색상 변경
- [x] 카카오맵 하단 레이아웃 수정
- [x] 카카오맵 클릭시 카카오맵 사이트로 이동
- [x] 카카오맵 이동 및 확대 고정
- [x] 굿즈 디테일 페이지 콘텐츠 내용 영역 크기 조정
- [x] 뒤로가기 svg 파일 여백 제거
- [x] 유저리스트 컴포넌트 색상 변경

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- close (#129 )
