### PR TITLE
🐛 Fix : 필터 인원 선택시 숫자로 넘어가도록 수정

### DIFF
--- a/src/apis/mateListService.ts
+++ b/src/apis/mateListService.ts
@@ -38,8 +38,14 @@ export const getMateList = async (params: MateListParams) => {
   }
   if (params.age) searchParams.append('age', params.age)
   if (params.gender) searchParams.append('gender', params.gender)
-  if (params.maxParticipants) searchParams.append('maxParticipants', params.maxParticipants)
-  if (params.transportType) searchParams.append('transportType', params.transportType)
+  if (params.maxParticipants) {
+    const parsedValue = parseInt(params.maxParticipants.replace('명', ''), 10)
+    if (!isNaN(parsedValue)) {
+      searchParams.append('maxParticipants', parsedValue.toString())
+    }
+  }
+  if (params.transportType)
+    searchParams.append('transportType', params.transportType)
 
   // 요청
   const response = await fetchApi.get(`mates?${searchParams.toString()}`).json()


### PR DESCRIPTION
## 🛠️ 구현한 기능
- `maxParticipants` 필터 값 처리 방식 수정
- "2명", "3명" 등 텍스트 값을 숫자로(2, 3 등) 변환하여 API 요청에 반영

## 📝 구현한 내용
- `maxParticipants` 값에서 "명"을 제거하고 숫자로 변환하여 URL 파라미터에 추가
- "상관 없음" 선택 시 해당 파라미터를 URL에 포함하지 않음

## ✅ 체크리스트
- [x] "2명" 선택 시 `maxParticipants=2`로 변환되는지 확인
- [x] "상관 없음" 선택 시 URL에 파라미터가 포함되지 않는지 확인

