### PR TITLE
GR / 굿즈 기록 페이지 API 연동

### DIFF
--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -22,6 +22,7 @@ export const QUERY_KEY = {
   RANKINGS: 'rankings',
   COMPLETED_MATCHES: 'completedMatches',
   GOODS_POST: 'goodsPost',
+  GOODS_RECORD: 'goodsRecord',
 }
 
 export default queryClient

--- a/src/apis/userService.ts
+++ b/src/apis/userService.ts
@@ -22,6 +22,14 @@ const userService = {
 
     return response
   },
+
+  getGoodsRecordList: async (memberId: number, callingType: string) => {
+    const response = await fetchApi
+      .get(`profile/${memberId}/goods/${callingType}`)
+      .json()
+
+    return response.data
+  },
 }
 
 export default userService

--- a/src/pages/GoodsRecordPage/GoodsRecordBox/index.tsx
+++ b/src/pages/GoodsRecordPage/GoodsRecordBox/index.tsx
@@ -9,42 +9,38 @@ import {
 } from '../style'
 
 import Placeholder from '@assets/default/placeholder.svg?react'
+import { ROUTE_PATH } from '@constants/ROUTE_PATH'
+import dayjs from 'dayjs'
 
 interface GoodsBoxPropTypes {
+  postId: number
   title: string
-  image?: string
+  imageUrl: string
   price: number
-  writer: string
-  createdAt: string // 추후 수정
+  author: string
+  createdAt: string
 }
 
 const GoodsRecordBox = ({
+  postId,
   title,
-  image,
+  imageUrl,
   price,
-  writer,
+  author,
   createdAt,
 }: GoodsBoxPropTypes) => {
-  const formattingDate = (createdAt: string) => {
-    const date = new Date(createdAt)
-
-    const year = date.getFullYear()
-    const month = ('0' + (date.getMonth() + 1)).slice(-2)
-    const day = ('0' + date.getDate()).slice(-2)
-
-    return `${year}-${month}-${day}`
-  }
+  const time = dayjs(createdAt)
 
   return (
     <Link
-      to={'/'}
+      to={`${ROUTE_PATH.GOODS_DETAIL}/${postId}`}
       style={{ width: '100%', display: 'block' }}
     >
       <GoodsRecordBoxWrap>
         <GoodsImageWrap>
-          {image ? (
+          {imageUrl ? (
             <img
-              src={image}
+              src={imageUrl}
               alt={title}
             />
           ) : (
@@ -55,8 +51,8 @@ const GoodsRecordBox = ({
           <GoodsRecordTitle>{title}</GoodsRecordTitle>
           <GoodsRecordPrice>{price.toLocaleString('ko-KR')}원</GoodsRecordPrice>
           <GoodsInfo>
-            <span>{writer}</span>
-            <span>{formattingDate(createdAt)}</span>
+            <span>{author}</span>
+            <span>{time.format('YYYY-MM-DD')}</span>
           </GoodsInfo>
         </GoodsRecordTextWrap>
       </GoodsRecordBoxWrap>

--- a/src/pages/GoodsRecordPage/index.tsx
+++ b/src/pages/GoodsRecordPage/index.tsx
@@ -1,32 +1,64 @@
 import SubHeader from '@layouts/SubHeader'
 import GoodsRecordBox from './GoodsRecordBox'
-import { GoodsSection } from './style'
+import { GoodsSection, NoGoodsList } from './style'
 import { GoodsRecordDataList } from './mockData'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { QUERY_KEY } from '@apis/queryClient'
+import userService from '@apis/userService'
+
+const HEADER_TEXT = {
+  sold: '굿즈 판매기록',
+  bought: '굿즈 구매기록',
+}
 
 const GoodsRecordPage = () => {
+  const location = useLocation()
+  const [memberId, setMemberId] = useState(1)
+  const [pageType, setPageType] = useState<('sold' | 'bought') | null>(
+    location.state.type,
+  )
   const [goodsRecordDataList, setGoodsRecordDataList] =
     useState(GoodsRecordDataList)
+
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: [QUERY_KEY, pageType],
+    queryFn: () =>
+      pageType && userService.getGoodsRecordList(memberId, pageType),
+  })
+
+  console.log(data)
+
+  useEffect(() => {
+    if (pageType === null) {
+      alert('어케들어왔누')
+    }
+  }, [])
 
   return (
     <>
       <SubHeader
         left='back'
-        center='굿즈 판매기록'
+        center={typeof pageType === 'string' ? HEADER_TEXT[pageType] : '페이지'}
       />
       <GoodsSection>
-        {goodsRecordDataList.map((data, index) => {
-          return (
-            <GoodsRecordBox
-              key={index}
-              title={data.title}
-              price={data.price}
-              writer={data.writer}
-              image={data.imgSrc}
-              createdAt={data.createdAt}
-            />
-          )
-        })}
+        {goodsRecordDataList.length === 0 ? (
+          <NoGoodsList>기록이 없습니다</NoGoodsList>
+        ) : (
+          goodsRecordDataList.map((data, index) => {
+            return (
+              <GoodsRecordBox
+                key={index}
+                title={data.title}
+                price={data.price}
+                author={data.writer}
+                imageUrl={data.imgSrc}
+                createdAt={data.createdAt}
+              />
+            )
+          })
+        )}
       </GoodsSection>
     </>
   )

--- a/src/pages/GoodsRecordPage/style.ts
+++ b/src/pages/GoodsRecordPage/style.ts
@@ -76,3 +76,14 @@ export const GoodsInfo = styled.div`
   font-weight: ${theme.fontWeight.regular};
   color: ${theme.fontColor.black};
 `
+
+export const NoGoodsList = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: ${theme.fontSize.xlarge};
+  font-weight: ${theme.fontWeight.semi};
+  font-size: ${theme.fontColor.black};
+`

--- a/src/pages/MainPage/MatchUpSection/index.tsx
+++ b/src/pages/MainPage/MatchUpSection/index.tsx
@@ -116,13 +116,15 @@ const MatchUpSection = ({ selectedTeam }: MatchUpSectionProps) => {
                 </TeamVersus>
                 <LocationWeather>
                   <UpdateInfo>
-                    {match.location} ({formatMatchTime(match.weather.wtTime)}{' '}
-                    기준)
+                    {match.weather &&
+                      ` (${formatMatchTime(match.weather.wtTime)} 기준)`}
                   </UpdateInfo>
-                  <Weather>
-                    {match.weather.temperature}°C, {match.weather.pop}% 강수
-                    확률
-                  </Weather>
+                  {match.weather && (
+                    <Weather>
+                      {match.weather.temperature}°C, {match.weather.pop}% 강수
+                      확률
+                    </Weather>
+                  )}
                 </LocationWeather>
               </MatchUpContainer>
             </SwiperSlide>

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -30,7 +30,7 @@ import { UserInfo } from '@typings/userForm'
 
 const ProfileMain = () => {
   const navigate = useNavigate()
-  const [userId, setUserId] = useState(1)
+  const [userId, setUserId] = useState(0)
   const [isMyProfile, setIsMyProfile] = useState<boolean | null>(null)
 
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
@@ -189,7 +189,10 @@ const ProfileMain = () => {
               </>
             )) || <Skeleton containerClassName='skeleton-flex' />}
           </Link>
-          <Link to={ROUTE_PATH.GOODS_RECORD}>
+          <Link
+            to={ROUTE_PATH.GOODS_RECORD}
+            state={{ type: 'sold' }}
+          >
             {(userInfo && (
               <>
                 <span>굿즈 판매기록 {userInfo.goodsSoldCount}개</span>
@@ -199,7 +202,10 @@ const ProfileMain = () => {
           </Link>
           {isMyProfile ? (
             <>
-              <Link to={ROUTE_PATH.GOODS_RECORD}>
+              <Link
+                to={ROUTE_PATH.GOODS_RECORD}
+                state={{ type: 'bought' }}
+              >
                 {(userInfo && (
                   <>
                     <span>굿즈 구매기록 {userInfo.goodsBoughtCount}개</span>


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 굿즈 기록 페이지 API 연동

## 📝 구현한 내용
- 굿즈 기록 페이지 API 연동
- 굿즈 기록 페이지 타입 검증 (판매 & 구매)
- 메인 페이지 매치업 섹션 wtTime null값 처리

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- close (#139 )
