### PR TITLE
Feat/#148 메인 페이지 팀 선택 문제 해결 및 기타

### DIFF
--- a/src/components/TeamSelectSection/index.tsx
+++ b/src/components/TeamSelectSection/index.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useRef } from 'react'
 import { TeamSelectContainer, Card } from './style'
 import { kboTeamList, kboTeamInfo } from '@constants/kboInfo'
 import KboWhiteLogo from '@assets/teamLogo/KBO_logo_white.svg?react'
@@ -14,17 +15,30 @@ const TeamSelectSection = ({
   onSelectTeam,
 }: TeamSelectSectionProps) => {
   const [kbo, ...restTeamList] = kboTeamList
-
   const KboLogo = kboTeamInfo[kbo.team].logo
+
+  const teamRefs = useRef<Map<number, HTMLDivElement | null>>(new Map())
 
   const handleTeamChange = (team: number) => {
     onSelectTeam(team)
   }
 
+  useEffect(() => {
+    const selectedRef = teamRefs.current.get(selectedTeam)
+    if (selectedRef) {
+      selectedRef.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center',
+      })
+    }
+  }, [selectedTeam])
+
   return (
     <TeamSelectContainer>
       <Card
-        onClick={() => onSelectTeam(KBO_NUMBER)}
+        ref={(el) => teamRefs.current.set(KBO_NUMBER, el)}
+        onClick={() => handleTeamChange(KBO_NUMBER)}
         $isSelected={selectedTeam === KBO_NUMBER}
       >
         {selectedTeam === KBO_NUMBER ? (
@@ -43,6 +57,7 @@ const TeamSelectSection = ({
       {restTeamList.map((team) => (
         <TeamCard
           key={team.id}
+          ref={(el) => teamRefs.current.set(team.id, el)}
           teamInfo={team}
           currentTeam={selectedTeam}
           onHandleTeamChange={handleTeamChange}
@@ -62,26 +77,25 @@ interface TeamCardProps {
   onHandleTeamChange: (team: number) => void
 }
 
-const TeamCard = ({
-  teamInfo,
-  currentTeam,
-  onHandleTeamChange,
-}: TeamCardProps) => {
-  const { team } = teamInfo
-  const Logo = kboTeamInfo[team].logo
-  const isSelected = currentTeam === teamInfo.id
+const TeamCard = React.forwardRef<HTMLDivElement, TeamCardProps>(
+  ({ teamInfo, currentTeam, onHandleTeamChange }, ref) => {
+    const { team } = teamInfo
+    const Logo = kboTeamInfo[team].logo
+    const isSelected = currentTeam === teamInfo.id
 
-  return (
-    <Card
-      onClick={() => onHandleTeamChange(teamInfo.id)}
-      $isSelected={isSelected}
-    >
-      <Logo
-        width={50}
-        height={50}
-      />
-    </Card>
-  )
-}
+    return (
+      <Card
+        ref={ref}
+        onClick={() => onHandleTeamChange(teamInfo.id)}
+        $isSelected={isSelected}
+      >
+        <Logo
+          width={50}
+          height={50}
+        />
+      </Card>
+    )
+  },
+)
 
 export default TeamSelectSection

--- a/src/components/TeamSelectSection/style.ts
+++ b/src/components/TeamSelectSection/style.ts
@@ -5,8 +5,6 @@ export const TeamSelectContainer = styled.div`
   overflow-x: scroll;
   gap: 12px;
 
-  /* 스크롤바 일단 살려둠 */
-
   &::-webkit-scrollbar {
     display: none;
   }

--- a/src/constants/kboInfo.tsx
+++ b/src/constants/kboInfo.tsx
@@ -93,6 +93,8 @@ const kboTeamList = Object.keys(kboTeamInfo).map((team) => ({
   team,
   id: kboTeamInfo[team].id,
   color: kboTeamInfo[team].color,
+  logo: kboTeamInfo[team].logo,
+  fullName: kboTeamInfo[team].team
 }))
 
 export { kboTeamInfo, kboTeamList }

--- a/src/layouts/Header/index.tsx
+++ b/src/layouts/Header/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { HeaderBox, LogoWrap } from './style'
 import Logo from '@assets/logo/logo_navy.svg?react'
-import Alarm from '@components/Alarm'
+// import Alarm from '@components/Alarm'
 const Header = () => {
   return (
     <HeaderBox>
@@ -10,7 +10,7 @@ const Header = () => {
           <Logo />
         </Link>
       </LogoWrap>
-      <Alarm />
+      {/* <Alarm /> */}
     </HeaderBox>
   )
 }

--- a/src/pages/MainPage/GoodsCardSection/index.tsx
+++ b/src/pages/MainPage/GoodsCardSection/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import GoodsCard from '@components/GoodsCard'
 import { GoodsCardContainer, CardWrapper, MoreSection } from './style'
-import { kboTeamInfo } from '@constants/kboInfo'
+import { kboTeamList } from '@constants/kboInfo'
 import { Link } from 'react-router-dom'
 import { QUERY_KEY } from '@apis/queryClient'
 import fetchApi from '@apis/ky'
@@ -9,14 +9,11 @@ import { GoodsPostSummary } from '@typings/db'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 
 interface GoodsCardSectionProps {
-  selectedTeam: string
+  selectedTeam: number
 }
 
-const fetchGoodsCards = async (
-  teamId: number | null,
-): Promise<GoodsPostSummary[]> => {
-  const endpoint =
-    teamId === null ? 'goods/main' : `goods/main?teamId=${teamId}`
+const fetchGoodsCards = async (teamId: number): Promise<GoodsPostSummary[]> => {
+  const endpoint = teamId === 0 ? 'goods/main' : `goods/main?teamId=${teamId}`
   const response = await fetchApi
     .get(endpoint)
     .json<{ data: GoodsPostSummary[] }>()
@@ -24,7 +21,7 @@ const fetchGoodsCards = async (
 }
 
 const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
-  const teamId = selectedTeam === '전체' ? null : kboTeamInfo[selectedTeam]?.id
+  const teamId = selectedTeam === 0 ? 0 : kboTeamList[selectedTeam].id
 
   const {
     data: goodsCards = [],
@@ -33,10 +30,10 @@ const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
   } = useQuery({
     queryKey: [QUERY_KEY.GOODS_LIST, teamId],
     queryFn: () => fetchGoodsCards(teamId),
-    enabled: !!teamId || selectedTeam === '전체',
+    enabled: !!teamId || selectedTeam === 0,
   })
 
-  const teamName = kboTeamInfo[selectedTeam]?.team || 'KBO'
+  const teamName = kboTeamList[selectedTeam]?.team || 'KBO'
 
   if (isLoading) {
     return (
@@ -50,9 +47,14 @@ const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
     return (
       <GoodsCardContainer>
         <h3>{`${teamName} 굿즈 거래하기`}</h3>
-        <p className='no-goods'>{`${teamName} 굿즈를 찾을 수 없습니다.`}  </p>
+        <p className='no-goods'>{`${teamName} 굿즈를 찾을 수 없습니다.`} </p>
         <MoreSection>
-          <Link className='more' to={ROUTE_PATH.GOODS_LIST}>더보기</Link>
+          <Link
+            className='more'
+            to={ROUTE_PATH.GOODS_LIST}
+          >
+            더보기
+          </Link>
         </MoreSection>
       </GoodsCardContainer>
     )
@@ -70,7 +72,12 @@ const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
         ))}
       </CardWrapper>
       <MoreSection>
-        <Link className='more' to={ROUTE_PATH.GOODS_LIST}>더보기</Link>
+        <Link
+          className='more'
+          to={ROUTE_PATH.GOODS_LIST}
+        >
+          더보기
+        </Link>
       </MoreSection>
     </GoodsCardContainer>
   )

--- a/src/pages/MainPage/MateCardSection/index.tsx
+++ b/src/pages/MainPage/MateCardSection/index.tsx
@@ -1,43 +1,33 @@
-import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import fetchApi from '@apis/ky'
 import { QUERY_KEY } from '@apis/queryClient'
-import { kboTeamInfo } from '@constants/kboInfo'
-import MateCard from '@components/MateCard'
+import { kboTeamList } from '@constants/kboInfo'
 import { MateCardContainer, MoreSection } from './style'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { MateCardData, MateCardResponse } from '@typings/db'
 import MainMateCard from '@components/MainMateCard'
 
 interface MateCardSectionProps {
-  selectedTeam: string
+  selectedTeam: number
 }
 
-const fetchMateCards = async (
-  teamId: number | null,
-): Promise<MateCardData[]> => {
-  const endpoint =
-    teamId === null ? 'mates/main' : `mates/main?teamId=${teamId}`
+const fetchMateCards = async (teamId: number): Promise<MateCardData[]> => {
+  const endpoint = teamId === 0 ? 'mates/main' : `mates/main?teamId=${teamId}`
   const response: MateCardResponse = await fetchApi.get(endpoint).json()
-  console.log(
-    '메이트 카드 데이터:',
-    `${import.meta.env.VITE_API_ENDPOINT}${endpoint}`,
-    response,
-  )
   return response.data
 }
 
 const MateCardSection = ({ selectedTeam }: MateCardSectionProps) => {
-  const teamId = selectedTeam === '전체' ? null : kboTeamInfo[selectedTeam]?.id
+  const teamId = selectedTeam === 0 ? 0 : kboTeamList[selectedTeam].id
 
   const { data: mateCards = [], isLoading } = useQuery({
     queryKey: [QUERY_KEY.MATE_POST, teamId],
     queryFn: () => fetchMateCards(teamId),
-    enabled: !!teamId || selectedTeam === '전체',
+    enabled: !!teamId || selectedTeam === 0,
   })
 
-  const teamName = kboTeamInfo[selectedTeam]?.team || 'KBO'
+  const teamName = kboTeamList[selectedTeam]?.team || 'KBO'
 
   if (isLoading) {
     return <div>로딩 중...</div>

--- a/src/pages/MainPage/RankingSection/index.tsx
+++ b/src/pages/MainPage/RankingSection/index.tsx
@@ -31,12 +31,12 @@ const RankingSection = () => {
 
   // 랭킹이 오전 9시에 업데이트되는 경우와 오후 10시에 업데이트되는 경우를 고려한 staleTime 계산
   const now = dayjs()
-  const nextUpdateHour = now.hour() < 9 ? 9 : 22 
+  const nextUpdateHour = now.hour() < 9 ? 9 : 22
 
   let nextUpdateTime =
     now.hour() >= 22
-      ? now.add(1, 'day').hour(9).minute(0).second(0).millisecond(0) 
-      : now.hour(nextUpdateHour).minute(0).second(0).millisecond(0) 
+      ? now.add(1, 'day').hour(9).minute(0).second(0).millisecond(0)
+      : now.hour(nextUpdateHour).minute(0).second(0).millisecond(0)
 
   const staleTime = nextUpdateTime.diff(now)
 
@@ -47,7 +47,7 @@ const RankingSection = () => {
   } = useQuery({
     queryKey: [QUERY_KEY.RANKINGS],
     queryFn: fetchTeamRankings,
-    staleTime
+    staleTime,
   })
 
   if (isLoading) {

--- a/src/pages/MainPage/ResultSection/ResultList/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultList/index.tsx
@@ -1,54 +1,65 @@
-import { useQuery } from '@tanstack/react-query';
-import { ResultListTable, RivalTeam, ResultListTitle, ErrorContainer } from './style';
-import { kboTeamInfo } from '@constants/kboInfo';
-import fetchApi from '@apis/ky';
-import { QUERY_KEY } from '@apis/queryClient';
-import { Match } from '@typings/db';
-import { formatTeamName } from '@utils/formatTeamName';
+import { useQuery } from '@tanstack/react-query'
+import {
+  ResultListTable,
+  RivalTeam,
+  ResultListTitle,
+  ErrorContainer,
+} from './style'
+import { kboTeamInfo, kboTeamList } from '@constants/kboInfo'
+import fetchApi from '@apis/ky'
+import { QUERY_KEY } from '@apis/queryClient'
+import { Match } from '@typings/db'
+import { formatTeamName } from '@utils/formatTeamName'
 
 interface ResultListProps {
-  teamKey: string; // 팀 이름 키
+  teamKey: number // 팀 이름 키
 }
 
 const fetchCompletedMatches = async (teamId: number): Promise<Match[]> => {
   const response = await fetchApi.get(`matches/team/${teamId}/completed`).json<{
-    status: string;
-    data: Match[];
-  }>();
+    status: string
+    data: Match[]
+  }>()
 
   if (response.status !== 'SUCCESS') {
-    throw new Error('경기 데이터를 불러오는 데 실패했습니다.');
+    throw new Error('경기 데이터를 불러오는 데 실패했습니다.')
   }
 
-  return response.data;
-};
+  return response.data
+}
 
 const ResultList = ({ teamKey }: ResultListProps) => {
-  const teamId = kboTeamInfo[teamKey]?.id;
+  const teamId = kboTeamList[teamKey]?.id
 
-  const { data: gameResults = [], isLoading, isError } = useQuery({
+  const {
+    data: gameResults = [],
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: [QUERY_KEY.COMPLETED_MATCHES, teamId],
     queryFn: () => fetchCompletedMatches(teamId!),
     enabled: !!teamId,
-  });
+  })
 
   if (isLoading) {
-    return <p>로딩 중...</p>;
+    return <p>로딩 중...</p>
   }
 
   if (isError || !gameResults.length) {
     return (
-      <ErrorContainer>  
-        <p className="error">
-          {`${kboTeamInfo[teamKey]?.team} 경기 전적을 불러올 수 없습니다.`}
+      <ErrorContainer>
+        <p className='error'>
+          {`${kboTeamList[teamKey]?.team} 경기 전적을 불러올 수 없습니다.`}
         </p>
       </ErrorContainer>
-    );
+    )
   }
 
   return (
     <div>
-      <ResultListTitle>{kboTeamInfo[teamKey]?.team}의 최근 전적</ResultListTitle>
+      <ResultListTitle>
+        {kboTeamList[teamKey]?.fullName}의 최근 전적
+      </ResultListTitle>
       <ResultListTable>
         <thead>
           <tr>
@@ -62,28 +73,29 @@ const ResultList = ({ teamKey }: ResultListProps) => {
         <tbody>
           {gameResults.map((game) => {
             const rivalTeamName =
-              game.homeTeam.teamName === kboTeamInfo[teamKey]?.team
+              game.homeTeam.teamName === kboTeamList[teamKey]?.fullName
                 ? game.awayTeam.teamName
-                : game.homeTeam.teamName;
+                : game.homeTeam.teamName
 
-            // formatTeamName으로 팀 이름 정리
-            const formattedRivalName = formatTeamName(rivalTeamName);
-            const teamInfo = kboTeamInfo[formattedRivalName] || {};
+            const formattedRivalName = formatTeamName(rivalTeamName)
+            const teamInfo = kboTeamInfo[formattedRivalName] || {}
 
             return (
               <tr key={game.id}>
-                <td className="date">
+                <td className='date'>
                   {new Date(game.matchTime).toLocaleDateString('ko-KR')}
                 </td>
-                <td className="vs">vs</td>
-                <td className="rival-team">
+                <td className='vs'>vs</td>
+                <td className='rival-team'>
                   <RivalTeam>
                     {teamInfo.logo ? (
-                      <teamInfo.logo className="team-logo" />
+                      <teamInfo.logo className='team-logo' />
                     ) : (
                       <span>로고 없음</span>
                     )}
-                    <span className="team-name">{teamInfo.team || '알 수 없음'}</span>
+                    <span className='team-name'>
+                      {teamInfo.team || '알 수 없음'}
+                    </span>
                   </RivalTeam>
                 </td>
                 <td
@@ -91,20 +103,24 @@ const ResultList = ({ teamKey }: ResultListProps) => {
                     game.result === 'WIN'
                       ? 'win'
                       : game.result === 'LOSE'
-                      ? 'loss'
-                      : 'draw'
+                        ? 'loss'
+                        : 'draw'
                   }`}
                 >
-                  {game.result === 'WIN' ? '승' : game.result === 'LOSE' ? '패' : '무'}
+                  {game.result === 'WIN'
+                    ? '승'
+                    : game.result === 'LOSE'
+                      ? '패'
+                      : '무'}
                 </td>
-                <td className="score">{`${game.homeScore}-${game.awayScore}`}</td>
+                <td className='score'>{`${game.homeScore}-${game.awayScore}`}</td>
               </tr>
-            );
+            )
           })}
         </tbody>
       </ResultListTable>
     </div>
-  );
-};
+  )
+}
 
-export default ResultList;
+export default ResultList

--- a/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
@@ -1,26 +1,66 @@
-import { ResultSummaryContainer, TeamInfo, GameStats } from './style';
-import { kboTeamInfo } from '@constants/kboInfo';
+import { ResultSummaryContainer, TeamInfo, GameStats } from './style'
+import { kboTeamList } from '@constants/kboInfo'
+import fetchApi from '@apis/ky'
+import { useQuery } from '@tanstack/react-query'
+import { QUERY_KEY } from '@apis/queryClient'
 
-interface ResultSummaryProps {
-  teamKey: string; // 팀 이름 키
+interface TeamRankingData {
+  rank: number
+  gamesPlayed: number
+  totalGames: number
+  wins: number
+  draws: number
+  losses: number
+  gamesBehind: number
 }
 
-const ResultSummary = ({ teamKey }: ResultSummaryProps) => {
-  const teamInfo = kboTeamInfo[teamKey]; // 팀 정보 가져오기
+const fetchTeamRanking = async (teamId: number): Promise<TeamRankingData> => {
+  const response = await fetchApi.get(`teams/rankings/${teamId}`).json<{
+    data: TeamRankingData
+  }>()
+  return response.data
+}
+
+interface ResultSummaryProps {
+  selectedTeam: number // 팀 아이디 키
+}
+
+const ResultSummary = ({ selectedTeam }: ResultSummaryProps) => {
+  const teamInfo = kboTeamList[selectedTeam]
+  const teamId = teamInfo?.id
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEY.RANKINGS, teamId],
+    queryFn: () => fetchTeamRanking(teamId!),
+    enabled: !!teamId,
+  })
+
+  if (isLoading) return <div>로딩 중...</div>
+  if (error instanceof Error) return <div>오류: {error.message}</div>
+
+  if (!data) return <div>순위 요약 데이터를 불러오지 못했습니다.</div>
+
+  const { rank, gamesPlayed, totalGames, wins, draws, losses } = data
 
   return (
-    <ResultSummaryContainer teamKey={teamKey}>
+    <ResultSummaryContainer $teamId={teamId}>
       <TeamInfo>
-        {teamInfo.logo && <teamInfo.logo className="logo" />} {/* 팀 로고 */}
-        <div className="team-name">{teamInfo.team}</div>
+        {teamInfo.logo && <teamInfo.logo className='logo' />}
+        <div className='team-name'>{teamInfo.team}</div>
+        <span>&nbsp;</span>
+        <span className='rank'>{rank}위</span>
       </TeamInfo>
       <GameStats>
-        <span className="total-games">144 / 144 경기</span>
+        <span className='total-games'>
+          {gamesPlayed} / {totalGames} 경기
+        </span>
         <span>&nbsp;&nbsp;&nbsp;&nbsp;</span>
-        <span className="win-draw-loss">61 승 2무 81패</span>
+        <span className='win-draw-loss'>
+          {wins}승 {draws}무 {losses}패
+        </span>
       </GameStats>
     </ResultSummaryContainer>
-  );
-};
+  )
+}
 
-export default ResultSummary;
+export default ResultSummary

--- a/src/pages/MainPage/ResultSection/ResultSummary/style.ts
+++ b/src/pages/MainPage/ResultSection/ResultSummary/style.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
 import { theme } from '@styles/theme'
-import { kboTeamInfo } from '@constants/kboInfo'
+import { kboTeamInfo,kboTeamList } from '@constants/kboInfo'
 
 interface ResultSummaryContainerProps {
-  teamKey: string // 팀 이름 키
+  $teamId: number // 팀 이름 키
 }
 
 export const ResultSummaryContainer = styled.div<ResultSummaryContainerProps>`
@@ -11,9 +11,9 @@ export const ResultSummaryContainer = styled.div<ResultSummaryContainerProps>`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 10px;
-  background-color: ${({ teamKey }) =>
-    kboTeamInfo[teamKey]?.color ||
-    '#004aad'}; /* 팀 색상 적용 (기본값: 파란색) */
+  background-color: ${({ $teamId }) =>
+    kboTeamList[$teamId]?.color ||
+    theme.fontColor.navy};
   padding: 8px 20px;
   color: ${theme.fontColor.white};
 `
@@ -28,7 +28,7 @@ export const TeamInfo = styled.div`
     margin-right: 10px;
   }
 
-  .team-name {
+  .team-name, .rank {
     font-size: ${theme.fontSize.small};
     font-weight: ${theme.fontWeight.regular};
   }
@@ -42,4 +42,7 @@ export const GameStats = styled.div`
   .win-draw-loss {
     margin-top: 5px;
   }
+`
+export const teamLogo = styled.img`
+
 `

--- a/src/pages/MainPage/ResultSection/index.tsx
+++ b/src/pages/MainPage/ResultSection/index.tsx
@@ -1,18 +1,18 @@
-import { ResultSectionContainer } from './style';
-import ResultSummary from './ResultSummary';
-import ResultList from './ResultList';
+import { ResultSectionContainer } from './style'
+import ResultSummary from './ResultSummary'
+import ResultList from './ResultList'
 
 interface ResultSectionProps {
-  selectedTeam: string;
+  selectedTeam: number
 }
 
 const ResultSection = ({ selectedTeam }: ResultSectionProps) => {
   return (
     <ResultSectionContainer>
-      <ResultSummary teamKey={selectedTeam} />
+      <ResultSummary selectedTeam={selectedTeam} />
       <ResultList teamKey={selectedTeam} />
     </ResultSectionContainer>
-  );
-};
+  )
+}
 
-export default ResultSection;
+export default ResultSection

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react';
-import { MainPageContainer, TeamSelectWrapper } from './style';
-import MatchUpSection from './MatchUpSection';
-import TeamSelectSection from '@components/TeamSelectSection';
-import MateCardSection from './MateCardSection';
-import GoodsCardSection from './GoodsCardSection';
-import RankingSection from './RankingSection';
-import ResultSection from './ResultSection';
-import { kboTeamList } from '@constants/kboInfo';
+import { useState } from 'react'
+import { MainPageContainer, TeamSelectWrapper } from './style'
+import MatchUpSection from './MatchUpSection'
+import MateCardSection from './MateCardSection'
+import GoodsCardSection from './GoodsCardSection'
+import RankingSection from './RankingSection'
+import ResultSection from './ResultSection'
+import TeamSelectSection from '@components/TeamSelectSection'
+import { kboTeamList } from '@constants/kboInfo'
 
 const MainPage = () => {
-  const [selectedTeam, setSelectedTeam] = useState<string>(kboTeamList[0].team);
+  const [selectedTeam, setSelectedTeam] = useState<number>(kboTeamList[0].id)
 
-  const handleTeamSelect = (team: string) => {
-    setSelectedTeam(team);
-  };
+  const handleTeamSelect = (team: number) => {
+    setSelectedTeam(team)
+  }
 
   return (
     <MainPageContainer>
@@ -22,7 +22,7 @@ const MainPage = () => {
       <TeamSelectWrapper>
         <TeamSelectSection
           selectedTeam={selectedTeam}
-          setSelectedTeam={handleTeamSelect}
+          onSelectTeam={handleTeamSelect}
         />
       </TeamSelectWrapper>
 
@@ -30,13 +30,13 @@ const MainPage = () => {
 
       <GoodsCardSection selectedTeam={selectedTeam} />
 
-      {selectedTeam === '전체' ? (
+      {selectedTeam === 0 ? (
         <RankingSection />
       ) : (
         <ResultSection selectedTeam={selectedTeam} />
       )}
     </MainPageContainer>
-  );
-};
+  )
+}
 
-export default MainPage;
+export default MainPage

--- a/src/pages/MateListPage/MateFilterOptions/index.tsx
+++ b/src/pages/MateListPage/MateFilterOptions/index.tsx
@@ -27,7 +27,7 @@ const MateFilterOptions: React.FC<MateFilterOptionsProps> = ({
     {
       label: '나이대',
       key: 'age',
-      value: ['상관 없음', '10대', '20대', '30대', '40대', '50대 이상'],
+      value: ['상관 없음', '10대', '20대', '30대', '40대', '50대이상'],
     },
     {
       label: '성별',


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 메이트 리스트 페이지의 일부 조건 미적용 문제 해결
- 메인 페이지 팀 선택 모달 미작동 문제 해결
- 팀 선택 섹션 클릭 시 자동 중앙 스크롤 기능 추가
- 사용하지 않는 알림 컴포넌트 주석 처리

## 📝 구현한 내용
### 1. 메이트 리스트 페이지 문제 해결
- **문제 원인**: "50대 이상" 조건이 "50대이상"으로 변경되며 조건이 정상적으로 적용되지 않음.
- **해결 방법**: 조건에서 불필요한 띄어쓰기 제거.

### 2. 메인 페이지 팀 선택 모달 문제 해결
- **문제 원인**:
  - 팀 선택 모달은 팀 아이디(숫자)를 전달.
  - 해당 데이터를 수신하는 컴포넌트는 팀 이름(문자열)을 받도록 구현.
- **해결 방법**: 전달 및 수신 데이터를 팀 아이디(숫자)로 통일.

### 3. 팀 선택 섹션 클릭 시 자동 중앙 스크롤 기능 추가
- **추가된 기능**: 팀 선택 섹션에서 특정 팀을 클릭하면 해당 팀이 화면 중앙에 위치하도록 자동 스크롤 기능 구현.

### 4. 사용하지 않는 알림 컴포넌트 주석 처리
- **변경 내용**: 현재 사용하지 않는 알림 컴포넌트를 주석 처리하여 코드 간결화.
- **목적**: 불필요한 코드 유지로 인한 가독성 저하 방지.

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 메이트 리스트 조건 문제 해결 및 팀 선택 모달 데이터 처리 방식 통일에 대해 코드 리뷰 요청.
- 자동 중앙 스크롤 기능에서 추가적으로 고려해야 할 부분이 있는지 확인 요청.
- 알림 컴포넌트 주석 처리 방식에 대해 팀 내에서 재사용 가능 여부 확인 요청.

## 🔗 연관된 이슈
- close #148 
