### PR TITLE
✨ Feat : 로그인 API에서 store로 유저인포 넘겨주는 기능 작성 #174

### DIFF
--- a/src/apis/loginService.ts
+++ b/src/apis/loginService.ts
@@ -1,11 +1,16 @@
 import fetchApi from '@apis/ky'
+import { useUserStore } from '@store/useUserStore'
 
 // 로그인 API 응답 타입 정의
 interface LoginResponseData {
-  memberId: number
-  grantType: string
   accessToken: string
+  age: number
+  gender: string
+  grantType: string
+  memberId: number
+  nickname: string
   refreshToken: string
+  teamId: number
 }
 
 interface LoginResponse {
@@ -15,6 +20,9 @@ interface LoginResponse {
   timestamp: string
   code: number
 }
+
+const { setAge, setGender, setMemberId, setNickname, setTeamId } =
+  useUserStore.getState()
 
 // 로그인 요청 함수
 export const loginPost = async (email: string): Promise<LoginResponseData> => {
@@ -37,6 +45,15 @@ export const loginPost = async (email: string): Promise<LoginResponseData> => {
     // localStorage.setItem('refreshToken', refreshToken);
 
     console.log('로그인 성공:', response.data)
+    const { age, gender, memberId, nickname, teamId } = response.data
+
+    // 상태 업데이트
+    setAge(age)
+    setGender(gender)
+    setMemberId(memberId)
+    setNickname(nickname)
+    setTeamId(teamId)
+
     return response.data // `data` 객체를 반환
   } catch (error) {
     console.error('로그인 실패:', error)

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+
+interface UserInfo {
+  age: number | null
+  gender: string
+  memberId: number | null
+  nickname: string
+  teamId: number | null
+}
+
+interface UserStore {
+  userInfo: UserInfo
+
+  setAge: (age: number) => void
+  setGender: (gender: string) => void
+  setMemberId: (memberId: number) => void
+  setNickname: (nickname: string) => void
+  setTeamId: (teamId: number) => void
+}
+
+const initialState = {
+  userInfo: {
+    age: null,
+    gender: '',
+    memberId: null,
+    nickname: '',
+    teamId: null,
+  },
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  ...initialState,
+
+  setAge: (age) => set((state) => ({ userInfo: { ...state.userInfo, age } })),
+  setGender: (gender) =>
+    set((state) => ({ userInfo: { ...state.userInfo, gender } })),
+  setMemberId: (memberId) =>
+    set((state) => ({ userInfo: { ...state.userInfo, memberId } })),
+  setNickname: (nickname) =>
+    set((state) => ({ userInfo: { ...state.userInfo, nickname } })),
+  setTeamId: (teamId) =>
+    set((state) => ({ userInfo: { ...state.userInfo, teamId } })),
+}))


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 유저 로그인 정보 스토어 저장 기능 추가

## 📝 구현한 내용
- 유저 로그인 정보 스토어 저장 기능 추가

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- close (#174 )
