### PR TITLE
🐛 Fix : 완료 버튼에 필터 적용되도록 적용

### DIFF
--- a/src/pages/MateListPage/index.tsx
+++ b/src/pages/MateListPage/index.tsx
@@ -39,18 +39,25 @@ const MateListPage = () => {
     maxParticipants: null,
     transportType: null,
   })
+  const [tempFilters, setTempFilters] = useState(selectedFilters)
+
+  // 필터 변경 핸들러 (임시 필터)
+  const handleTempFilterChange = (filters: Partial<typeof tempFilters>) => {
+    setTempFilters((prevFilters) => ({
+      ...prevFilters,
+      ...filters,
+    }))
+  }
+
+  // "완료" 버튼 핸들러
+  const applyFilters = () => {
+    setSelectedFilters(tempFilters) // 임시 필터를 실제 필터로 반영
+    handleCloseBottomModal()
+  }
 
   // 팀 선택 핸들러
   const handleTeamSelect = (team: number | null) => {
     setSelectedTeam(team)
-  }
-
-  // 필터 변경 핸들러
-  const handleFilterChange = (filters: Partial<typeof selectedFilters>) => {
-    setSelectedFilters((prevFilters) => ({
-      ...prevFilters,
-      ...filters,
-    }))
   }
 
   // 페이지 상단 버튼 핸들러
@@ -71,6 +78,7 @@ const MateListPage = () => {
 
       getNextPageParam: (lastPage: any) =>
         lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
+
     })
 
   // 무한 스크롤 핸들러
@@ -131,9 +139,9 @@ const MateListPage = () => {
 
       <BottomModal ref={bottomModalRef}>
         <MateFilterOptions
-          onClose={handleCloseBottomModal}
-          selectedFilters={selectedFilters}
-          onFilterChange={handleFilterChange}
+          onClose={applyFilters}
+          selectedFilters={tempFilters} // 임시 필터 전달
+          onFilterChange={handleTempFilterChange}
         />
       </BottomModal>
     </section>
@@ -141,3 +149,5 @@ const MateListPage = () => {
 }
 
 export default MateListPage
+
+


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 메이트 필터 적용 방식 개선
- 임시 필터 상태 추가 및 "완료" 버튼 기능 구현

## 📝 구현한 내용
- 필터 변경 시 임시 상태(`tempFilters`)를 활용하도록 수정하여, 모달에서 필터를 수정한 후 "완료" 버튼을 누르기 전까지 실제 필터(`selectedFilters`)가 변경되지 않도록 로직 개선.
- "완료" 버튼 클릭 시 임시 필터 상태를 실제 필터 상태로 반영하는 `applyFilters` 함수 추가.
- `MateFilterOptions` 컴포넌트에 임시 필터 상태(`tempFilters`)와 임시 필터 변경 핸들러(`handleTempFilterChange`)를 전달하도록 수정.
- 기존 필터 변경 로직을 `handleTempFilterChange`로 이동하여 필터 변경 시 임시 필터만 업데이트되도록 변경.

## ✅ 체크리스트
- [x] 임시 필터와 실제 필터 상태를 분리하여 기능 구현
- [x] "완료" 버튼 클릭 시 임시 필터가 실제 필터에 반영되는지 확인
- [x] 무한 스크롤 및 메이트 목록 조회 기능과의 호환성 확인

## 💬 리뷰 요구 사항
- 기존 필터 변경 로직에서 발생할 수 있는 예상치 못한 동작이 개선되었는지 확인 부탁드립니다.
- `tempFilters`를 활용한 임시 상태 관리 로직이 적절한지에 대한 의견 부탁드립니다.
- 팀 선택 시 화면 전체가 리렌더링되는 버그에 대한 원인과 개선 방안에 대해 추가로 확인 필요합니다.

## 🔗 연관된 이슈
- close #149 
