### PR TITLE
로그인 정보 store 저장 & 프로필 하위 페이지 API 충돌 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-kakao-maps-sdk": "^1.1.27",
         "react-loading-skeleton": "^3.5.0",
         "react-router-dom": "^6.28.0",
+        "react-toastify": "^10.0.6",
         "sockjs-client": "^1.6.1",
         "styled-components": "^6.1.13",
         "styled-normalize": "^8.1.1",
@@ -2807,6 +2808,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5692,6 +5702,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-kakao-maps-sdk": "^1.1.27",
     "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "^6.28.0",
+    "react-toastify": "^10.0.6",
     "sockjs-client": "^1.6.1",
     "styled-components": "^6.1.13",
     "styled-normalize": "^8.1.1",

--- a/src/apis/loginService.ts
+++ b/src/apis/loginService.ts
@@ -1,11 +1,16 @@
 import fetchApi from '@apis/ky'
+import { useUserStore } from '@store/useUserStore'
 
 // 로그인 API 응답 타입 정의
 interface LoginResponseData {
-  memberId: number
-  grantType: string
   accessToken: string
+  age: number
+  gender: string
+  grantType: string
+  memberId: number
+  nickname: string
   refreshToken: string
+  teamId: number
 }
 
 interface LoginResponse {
@@ -15,6 +20,9 @@ interface LoginResponse {
   timestamp: string
   code: number
 }
+
+const { setAge, setGender, setMemberId, setNickname, setTeamId } =
+  useUserStore.getState()
 
 // 로그인 요청 함수
 export const loginPost = async (email: string): Promise<LoginResponseData> => {
@@ -37,6 +45,15 @@ export const loginPost = async (email: string): Promise<LoginResponseData> => {
     // localStorage.setItem('refreshToken', refreshToken);
 
     console.log('로그인 성공:', response.data)
+    const { age, gender, memberId, nickname, teamId } = response.data
+
+    // 상태 업데이트
+    setAge(age)
+    setGender(gender)
+    setMemberId(memberId)
+    setNickname(nickname)
+    setTeamId(teamId)
+
     return response.data // `data` 객체를 반환
   } catch (error) {
     console.error('로그인 실패:', error)

--- a/src/hooks/useEditMyInfo.ts
+++ b/src/hooks/useEditMyInfo.ts
@@ -1,12 +1,16 @@
 import queryClient, { QUERY_KEY } from '@apis/queryClient'
 import userService from '@apis/userService'
+import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'react-toastify'
 
 const useEditMyInfo = () => {
-  const { mutate, isPending, isError, error } = useMutation({
+  const { mutate, isPending, isError, error, isSuccess } = useMutation({
     mutationFn: (formData: FormData) => userService.editMyInfo(formData),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.MY_INFO, 1] })
+      toast('정보 수정이 완료되었습니다.')
     },
     onSettled: (data, error) => {
       console.log(data, error)
@@ -16,7 +20,7 @@ const useEditMyInfo = () => {
     },
   })
 
-  return { mutateMyInfo: mutate, isPending, isError, error }
+  return { mutateMyInfo: mutate, isPending, isError, error, isSuccess }
 }
 
 export default useEditMyInfo

--- a/src/layouts/GlobalNav/index.tsx
+++ b/src/layouts/GlobalNav/index.tsx
@@ -13,10 +13,12 @@ import UserIconFill from '@assets/icon/nav_user_fill.svg?react'
 import { Link, useLocation } from 'react-router-dom'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { useEffect, useState } from 'react'
+import { useUserStore } from '@store/useUserStore'
 
 const GlobalNav = () => {
   const { pathname } = useLocation()
   const [isLogin, setIsLogin] = useState<boolean>(false)
+  const { memberId } = useUserStore().userInfo
 
   useEffect(() => {
     const token = localStorage.getItem('token')
@@ -64,7 +66,7 @@ const GlobalNav = () => {
 
         <NavList>
           {isLogin ? (
-            <Link to={ROUTE_PATH.PROFILE}>
+            <Link to={`${ROUTE_PATH.PROFILE}/${memberId}`}>
               {pathname === ROUTE_PATH.PROFILE ? (
                 <UserIconFill />
               ) : (

--- a/src/layouts/GlobalNav/index.tsx
+++ b/src/layouts/GlobalNav/index.tsx
@@ -12,9 +12,16 @@ import UserIcon from '@assets/icon/nav_user.svg?react'
 import UserIconFill from '@assets/icon/nav_user_fill.svg?react'
 import { Link, useLocation } from 'react-router-dom'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
+import { useEffect, useState } from 'react'
 
 const GlobalNav = () => {
   const { pathname } = useLocation()
+  const [isLogin, setIsLogin] = useState<boolean>(false)
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    setIsLogin(!!token)
+  }, [pathname])
 
   return (
     <NavWrap>
@@ -56,10 +63,25 @@ const GlobalNav = () => {
         </NavList>
 
         <NavList>
-          <Link to={ROUTE_PATH.PROFILE}>
-            {pathname === ROUTE_PATH.PROFILE ? <UserIconFill /> : <UserIcon />}
-            <NavText>마이</NavText>
-          </Link>
+          {isLogin ? (
+            <Link to={ROUTE_PATH.PROFILE}>
+              {pathname === ROUTE_PATH.PROFILE ? (
+                <UserIconFill />
+              ) : (
+                <UserIcon />
+              )}
+              <NavText>마이</NavText>
+            </Link>
+          ) : (
+            <Link to={ROUTE_PATH.LOGIN}>
+              {pathname === ROUTE_PATH.PROFILE ? (
+                <UserIconFill />
+              ) : (
+                <UserIcon />
+              )}
+              <NavText>로그인</NavText>
+            </Link>
+          )}
         </NavList>
       </NavUl>
     </NavWrap>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,10 @@ import { GlobalStyle } from '@styles/globalStyle'
 import { ThemeProvider } from 'styled-components'
 import { theme } from '@styles/theme'
 import queryClient from '@apis/queryClient'
-import App from './App'
 import { SkeletonTheme } from 'react-loading-skeleton'
+import { ToastContainer } from 'react-toastify'
+import App from './App'
+import 'react-toastify/ReactToastify.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -16,6 +18,11 @@ createRoot(document.getElementById('root')!).render(
           baseColor='#313131'
           highlightColor='#525252'
         >
+          <ToastContainer
+            position='top-center'
+            autoClose={3000}
+            closeOnClick
+          />
           <GlobalStyle />
           <App />
         </SkeletonTheme>

--- a/src/pages/GoodsRecordPage/index.tsx
+++ b/src/pages/GoodsRecordPage/index.tsx
@@ -2,7 +2,7 @@ import SubHeader from '@layouts/SubHeader'
 import GoodsRecordBox from './GoodsRecordBox'
 import { GoodsSection, NoGoodsList } from './style'
 import { useEffect, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { QUERY_KEY } from '@apis/queryClient'
 import userService from '@apis/userService'
@@ -24,6 +24,7 @@ interface GoodsRecord {
 
 const GoodsRecordPage = () => {
   const location = useLocation()
+  const { id } = useParams()
   const [memberId, setMemberId] = useState(1)
   const [pageType, setPageType] = useState<('sold' | 'bought') | null>(
     location.state.type,
@@ -36,7 +37,7 @@ const GoodsRecordPage = () => {
 
       queryFn: ({ pageParam }) =>
         pageType &&
-        userService.getGoodsRecordList(memberId, pageType, pageParam),
+        userService.getGoodsRecordList(Number(id), pageType, pageParam),
 
       initialPageParam: 0,
 

--- a/src/pages/ProfilePage/ProfileEdit.tsx
+++ b/src/pages/ProfilePage/ProfileEdit.tsx
@@ -2,6 +2,7 @@ import {
   ProfileEditInputWrap,
   ProfileImageEdit,
   ProfileImageEditWrap,
+  ProfileSpinnerWrap,
 } from './style'
 import { FormEvent, useEffect, useState } from 'react'
 import { handleImageUpload } from './methods'
@@ -13,15 +14,23 @@ import useTeamDialog from '@hooks/useTeamDialog'
 import BottomModalOption from './BottomModalOption'
 import SubHeader from '@layouts/SubHeader'
 import useEditMyInfo from '@hooks/useEditMyInfo'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { UserInfo } from '@typings/userForm'
 import { kboTeamInfo } from '@constants/kboInfo'
+import { toast } from 'react-toastify'
+import { ROUTE_PATH } from '@constants/ROUTE_PATH'
+import Spinner from '@components/Spinner'
+import { useUserStore } from '@store/useUserStore'
 
 // 소개글 글자제한
 const MAX_LENGTH = 500
 
 const ProfileEdit = () => {
   const location = useLocation()
+  const navigate = useNavigate()
+
+  const { memberId } = useUserStore().userInfo
+
   const [isUpload, setIsUpload] = useState(false)
   const [currentTeamId, setCurrentTeamId] = useState<number | null>(null)
   const [profileImg, setProfileImg] = useState<File | undefined>(undefined)
@@ -30,7 +39,7 @@ const ProfileEdit = () => {
     undefined,
   )
 
-  const { mutateMyInfo, error, isError, isPending } = useEditMyInfo()
+  const { mutateMyInfo, error, isError, isPending, isSuccess } = useEditMyInfo()
 
   // 프로파일 수정 사항 서브밋
   const onProfileEditSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -51,7 +60,10 @@ const ProfileEdit = () => {
     )
     profileImg && formData.append('image', profileImg)
 
-    mutateMyInfo(formData)
+    try {
+      mutateMyInfo(formData)
+      navigate(`${ROUTE_PATH.PROFILE}/${memberId}`)
+    } catch (err) {}
   }
 
   // 소개글 글자제한
@@ -95,6 +107,11 @@ const ProfileEdit = () => {
     <>
       {/* 폼 (내용) */}
       <form onSubmit={onProfileEditSubmit}>
+        {isPending ? (
+          <ProfileSpinnerWrap>
+            <Spinner />
+          </ProfileSpinnerWrap>
+        ) : null}
         {/* 서브헤더 */}
         <SubHeader
           left='exit'
@@ -158,7 +175,7 @@ const ProfileEdit = () => {
             }}
           ></textarea>
           <p>
-            {userInfo?.aboutMe.length}/{MAX_LENGTH}
+            {userInfo?.aboutMe ? userInfo?.aboutMe.length : '0'}/{MAX_LENGTH}
           </p>
         </ProfileEditInputWrap>
 

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -21,26 +21,32 @@ import SubHeader from '@layouts/SubHeader'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import useGetUserInfo from '@hooks/useGetUserInfo'
 
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import Skeleton from 'react-loading-skeleton'
 import 'react-loading-skeleton/dist/skeleton.css'
 import useGetMyInfo from '@hooks/useGetMyInfo'
 import { UserInfo } from '@typings/userForm'
+import { toast } from 'react-toastify'
+import { useUserStore } from '@store/useUserStore'
 
 const ProfileMain = () => {
   const navigate = useNavigate()
-  const [userId, setUserId] = useState(0)
-  const [isMyProfile, setIsMyProfile] = useState<boolean | null>(null)
+  const { id } = useParams()
 
+  const { memberId: loginMemberId } = useUserStore().userInfo
+
+  const [userId, setUserId] = useState(id)
+  const [isMyProfile, setIsMyProfile] = useState<boolean | null>(null)
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
 
-  const myInfoResult = useGetMyInfo(1)
-  const userInfoResult = useGetUserInfo(2)
+  const myInfoResult = useGetMyInfo(loginMemberId)
+  const userInfoResult = useGetUserInfo(
+    typeof id === 'string' ? Number(id) : null,
+  )
 
   useEffect(() => {
-    const currentUserId = localStorage.getItem('userId')
-    if (Number(currentUserId) === userId) {
+    if (loginMemberId === Number(userId)) {
       setIsMyProfile(true)
     } else {
       setIsMyProfile(false)
@@ -72,20 +78,12 @@ const ProfileMain = () => {
         {/* 프로필 상단 섹션 */}
         <ProfileTopWrap>
           <ProfileEditWrap>
-            {myInfoResult.isPending || userInfoResult.isPending ? (
-              <Skeleton
-                circle
-                width={'5.3125em'}
-                height={'5.3125em'}
-              />
-            ) : (
-              <ProfileBedge
-                width={5.3125}
-                height={5.3125}
-                imageSrc={userInfo?.imageUrl}
-                myTeam={userInfo?.teamName}
-              />
-            )}
+            <ProfileBedge
+              width={5.3125}
+              height={5.3125}
+              imageSrc={userInfo?.imageUrl}
+              myTeam={userInfo?.teamName}
+            />
             <ProfileUserNickname>
               {(userInfo && userInfo.nickname) || <Skeleton />}
             </ProfileUserNickname>
@@ -100,23 +98,11 @@ const ProfileMain = () => {
             <Link to={ROUTE_PATH.FOLLOW}>
               <div>
                 <p>팔로우</p>
-                <p>
-                  {myInfoResult.isPending || userInfoResult.isPending ? (
-                    <Skeleton />
-                  ) : (
-                    userInfo?.followingCount
-                  )}
-                </p>
+                <p>{userInfo?.followingCount}</p>
               </div>
               <div>
                 <p>팔로워</p>
-                <p>
-                  {myInfoResult.isPending || userInfoResult.isPending ? (
-                    <Skeleton />
-                  ) : (
-                    userInfo?.followerCount
-                  )}
-                </p>
+                <p>{userInfo?.followerCount}</p>
               </div>
             </Link>
           </ProfileFollowWrap>
@@ -124,7 +110,7 @@ const ProfileMain = () => {
 
         {/* 프로필 소개 섹션 */}
         <ProfileNotice>
-          <p>{(userInfo && userInfo.aboutMe) || <Skeleton />}</p>
+          <p>{userInfo?.aboutMe}</p>
         </ProfileNotice>
 
         {/* 프로필 상단 버튼 본인 프로필 유무 */}
@@ -181,45 +167,29 @@ const ProfileMain = () => {
 
         {/* 프로필 하단 이동 섹션 */}
         <ProfileLinkWrap>
-          <Link to={ROUTE_PATH.REVIEW}>
-            {(userInfo && (
-              <>
-                <span>후기 모아보기 {userInfo.reviewsCount}개</span>
-                <LinkIcon />
-              </>
-            )) || <Skeleton containerClassName='skeleton-flex' />}
+          <Link to={`${ROUTE_PATH.REVIEW}/${id}`}>
+            <span>후기 모아보기 {userInfo?.reviewsCount}개</span>
+            <LinkIcon />
           </Link>
           <Link
-            to={ROUTE_PATH.GOODS_RECORD}
+            to={`${ROUTE_PATH.GOODS_RECORD}/${id}`}
             state={{ type: 'sold' }}
           >
-            {(userInfo && (
-              <>
-                <span>굿즈 판매기록 {userInfo.goodsSoldCount}개</span>
-                <LinkIcon />
-              </>
-            )) || <Skeleton containerClassName='skeleton-flex' />}
+            <span>굿즈 판매기록 {userInfo?.goodsSoldCount}개</span>
+            <LinkIcon />
           </Link>
           {isMyProfile ? (
             <>
               <Link
-                to={ROUTE_PATH.GOODS_RECORD}
+                to={`${ROUTE_PATH.GOODS_RECORD}/${id}`}
                 state={{ type: 'bought' }}
               >
-                {(userInfo && (
-                  <>
-                    <span>굿즈 구매기록 {userInfo.goodsBoughtCount}개</span>
-                    <LinkIcon />
-                  </>
-                )) || <Skeleton containerClassName='skeleton-flex' />}
+                <span>굿즈 구매기록 {userInfo?.goodsBoughtCount}개</span>
+                <LinkIcon />
               </Link>
               <Link to={ROUTE_PATH.TIMELINE}>
-                {(userInfo && (
-                  <>
-                    <span>직관 보관기록 {userInfo.visitsCount}개</span>
-                    <LinkIcon />
-                  </>
-                )) || <Skeleton containerClassName='skeleton-flex' />}
+                <span>직관 보관기록 {userInfo?.visitsCount}개</span>
+                <LinkIcon />
               </Link>
             </>
           ) : null}

--- a/src/pages/ProfilePage/ReviewBoxComponent/index.tsx
+++ b/src/pages/ProfilePage/ReviewBoxComponent/index.tsx
@@ -21,7 +21,7 @@ const ReviewBoxComponent = ({
 }) => {
   return (
     <ReviewWrap>
-      {reviewList ? (
+      {reviewList && reviewList.length !== 0 ? (
         reviewList.map((data, index) => {
           return (
             <ReviewBox key={index}>
@@ -46,7 +46,7 @@ const ReviewBoxComponent = ({
           )
         })
       ) : (
-        <div>데이터가 비어있습니다</div>
+        <div>아직 받은 후기가 없습니다</div>
       )}
     </ReviewWrap>
   )

--- a/src/pages/ProfilePage/ReviewPage.tsx
+++ b/src/pages/ProfilePage/ReviewPage.tsx
@@ -8,11 +8,13 @@ import { QUERY_KEY } from '@apis/queryClient'
 import reviewService from '@apis/reviewService'
 import ReviewBoxComponent from './ReviewBoxComponent'
 import { useInView } from 'react-intersection-observer'
+import { useParams } from 'react-router-dom'
 
 const GOODS_REVIEW = '1'
 const MATE_REVIEW = '2'
 
 const ReviewPage = () => {
+  const { id: pageId } = useParams()
   const [selectedReview, setSelectedReview] = useState(GOODS_REVIEW)
   const { ref, inView } = useInView({
     threshold: 0.9,
@@ -33,7 +35,7 @@ const ReviewPage = () => {
       queryFn: ({ pageParam }) =>
         reviewService.getReviewList(
           decideReviewType(selectedReview),
-          1,
+          Number(pageId),
           pageParam,
         ),
       initialPageParam: 0,

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -360,3 +360,11 @@ export const ReviewLinkBox = styled.div`
     }
   }
 `
+
+export const ProfileSpinnerWrap = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -56,9 +56,9 @@ const AppRoutes = () => {
           path={ROUTE_PATH.LOGIN}
           element={<LoginPage />}
         />
-        <Route 
+        <Route
           path={ROUTE_PATH.NAVER_CALLBACK}
-          element={<NaverCallback/>}
+          element={<NaverCallback />}
         />
         <Route
           path={ROUTE_PATH.SIGNUP}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -107,7 +107,7 @@ const AppRoutes = () => {
           />
         </Route>
         <Route
-          path={ROUTE_PATH.GOODS_RECORD}
+          path={`${ROUTE_PATH.GOODS_RECORD}/:id`}
           element={<GoodsRecordPage />}
         />
         <Route
@@ -115,7 +115,7 @@ const AppRoutes = () => {
           element={<FollowPage />}
         />
         <Route
-          path={ROUTE_PATH.PROFILE}
+          path={`${ROUTE_PATH.PROFILE}/:id`}
           element={<ProfileMain />}
         />
         <Route
@@ -123,7 +123,7 @@ const AppRoutes = () => {
           element={<ProfileEdit />}
         />
         <Route
-          path={ROUTE_PATH.REVIEW}
+          path={`${ROUTE_PATH.REVIEW}/:id`}
           element={<ReviewPage />}
         />
         <Route
@@ -131,7 +131,7 @@ const AppRoutes = () => {
           element={<ReviewWritePage />}
         />
         <Route
-          path={ROUTE_PATH.TIMELINE}
+          path={`${ROUTE_PATH.TIMELINE}`}
           element={<TimelinePage />}
         />
       </Route>

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+
+interface UserInfo {
+  age: number | null
+  gender: string
+  memberId: number | null
+  nickname: string
+  teamId: number | null
+}
+
+interface UserStore {
+  userInfo: UserInfo
+
+  setAge: (age: number) => void
+  setGender: (gender: string) => void
+  setMemberId: (memberId: number) => void
+  setNickname: (nickname: string) => void
+  setTeamId: (teamId: number) => void
+}
+
+const initialState = {
+  userInfo: {
+    age: null,
+    gender: '',
+    memberId: null,
+    nickname: '',
+    teamId: null,
+  },
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  ...initialState,
+
+  setAge: (age) => set((state) => ({ userInfo: { ...state.userInfo, age } })),
+  setGender: (gender) =>
+    set((state) => ({ userInfo: { ...state.userInfo, gender } })),
+  setMemberId: (memberId) =>
+    set((state) => ({ userInfo: { ...state.userInfo, memberId } })),
+  setNickname: (nickname) =>
+    set((state) => ({ userInfo: { ...state.userInfo, nickname } })),
+  setTeamId: (teamId) =>
+    set((state) => ({ userInfo: { ...state.userInfo, teamId } })),
+}))


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 로그인 정보 store 저장 & 프로필 하위 페이지 API 충돌 제거

## 📝 구현한 내용
- 로그인 정보 store 저장
- 프로필 하위 페이지 API 충돌 제거

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- 

## 🔗 연관된 이슈
- close (#이슈 번호)
