### PR TITLE
Feat/#186 회원 탈퇴 기능 연동

### DIFF
--- a/src/apis/unregisterService.ts
+++ b/src/apis/unregisterService.ts
@@ -1,0 +1,7 @@
+import fetchApi from "@apis/ky";
+import { logoutPost } from "@apis/logoutService";
+
+export const unregisterDelete = async () => {
+    await fetchApi.delete('members/me')
+    logoutPost()
+}

--- a/src/constants/alertMessage.ts
+++ b/src/constants/alertMessage.ts
@@ -66,6 +66,13 @@ const ALERT_MESSAGE = {
     actionText: '삭제하기',
     cancelText: '취소',
   },
+  
+  UNREGISTER: {
+    title: '회원 탈퇴',
+    notice: '회원 탈퇴하시겠습니까?',
+    actionText: '탈퇴하기',
+    cancelText: '취소',
+  },
 }
 
 export type AlertMessage = keyof typeof ALERT_MESSAGE

--- a/src/layouts/GlobalNav/index.tsx
+++ b/src/layouts/GlobalNav/index.tsx
@@ -13,7 +13,6 @@ import UserIconFill from '@assets/icon/nav_user_fill.svg?react'
 import { Link, useLocation } from 'react-router-dom'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { useEffect, useState } from 'react'
-import { useUserStore } from '@store/useUserStore'
 
 const GlobalNav = () => {
   const { pathname } = useLocation()
@@ -36,32 +35,53 @@ const GlobalNav = () => {
         </NavList>
 
         <NavList>
-          <Link to={ROUTE_PATH.MATE_LIST}>
-            {pathname === ROUTE_PATH.MATE_LIST ? (
-              <FindIconFill />
-            ) : (
+          {isLogin ? (
+            <Link to={ROUTE_PATH.MATE_LIST}>
+              {pathname === ROUTE_PATH.MATE_LIST ? (
+                <FindIconFill />
+              ) : (
+                <FindIcon />
+              )}
+              <NavText>메이트 찾기</NavText>
+            </Link>
+          ) : (
+            <Link to={ROUTE_PATH.LOGIN}>
               <FindIcon />
-            )}
-            <NavText>메이트 찾기</NavText>
-          </Link>
+              <NavText>메이트 찾기</NavText>
+            </Link>
+          )}
         </NavList>
 
         <NavList>
-          <Link to={ROUTE_PATH.GOODS_LIST}>
-            {pathname === ROUTE_PATH.GOODS_LIST ? (
-              <TradeIconFill />
-            ) : (
+          {isLogin ? (
+            <Link to={ROUTE_PATH.GOODS_LIST}>
+              {pathname === ROUTE_PATH.GOODS_LIST ? (
+                <TradeIconFill />
+              ) : (
+                <TradeIcon />
+              )}
+              <NavText>굿즈거래</NavText>
+            </Link>
+          ) : (
+            <Link to={ROUTE_PATH.LOGIN}>
               <TradeIcon />
-            )}
-            <NavText>굿즈거래</NavText>
-          </Link>
+              <NavText>굿즈거래</NavText>
+            </Link>
+          )}
         </NavList>
 
         <NavList>
-          <Link to={ROUTE_PATH.CHAT}>
-            {pathname === ROUTE_PATH.CHAT ? <ChatIconFill /> : <ChatIcon />}
-            <NavText>채팅</NavText>
-          </Link>
+          {isLogin ? (
+            <Link to={ROUTE_PATH.CHAT}>
+              {pathname === ROUTE_PATH.CHAT ? <ChatIconFill /> : <ChatIcon />}
+              <NavText>채팅</NavText>
+            </Link>
+          ) : (
+            <Link to={ROUTE_PATH.LOGIN}>
+              <ChatIcon />
+              <NavText>채팅</NavText>
+            </Link>
+          )}
         </NavList>
 
         <NavList>

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -59,7 +59,7 @@ const ProfileMain = () => {
   const confirmLogout = async () => {
     try {
       await logoutPost()
-      localStorage.removeItem('token')
+      localStorage.clear()
       if (alertRef.current) {
         alertRef.current.close()
       }

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -33,9 +33,12 @@ import { useUserStore } from '@store/useUserStore'
 import Alert from '@components/Alert'
 import ALERT_MESSAGE from '@constants/alertMessage'
 import { logoutPost } from '@apis/logoutService'
+import { unregisterDelete } from '@apis/unregisterService'
 
 const ProfileMain = () => {
-  const alertRef = useRef<HTMLDialogElement | null>(null)
+  const logoutAlertRef = useRef<HTMLDialogElement | null>(null) // 로그아웃용 ref
+  const unregisterAlertRef = useRef<HTMLDialogElement | null>(null) // 회원탈퇴용 ref
+
   const navigate = useNavigate()
   const { id } = useParams()
 
@@ -51,8 +54,8 @@ const ProfileMain = () => {
   )
 
   const handleLogoutClick = () => {
-    if (alertRef.current) {
-      alertRef.current.showModal()
+    if (logoutAlertRef.current) {
+      logoutAlertRef.current.showModal()
     }
   }
 
@@ -60,8 +63,8 @@ const ProfileMain = () => {
     try {
       await logoutPost()
       localStorage.clear()
-      if (alertRef.current) {
-        alertRef.current.close()
+      if (logoutAlertRef.current) {
+        logoutAlertRef.current.close()
       }
       navigate(ROUTE_PATH.HOME)
     } catch (error) {
@@ -101,7 +104,7 @@ const ProfileMain = () => {
         onLogoutClick={handleLogoutClick}
       />
       <Alert
-        ref={alertRef}
+        ref={logoutAlertRef}
         title={ALERT_MESSAGE.LOGOUT.title}
         notice={ALERT_MESSAGE.LOGOUT.notice}
         actionText={ALERT_MESSAGE.LOGOUT.actionText}
@@ -228,6 +231,35 @@ const ProfileMain = () => {
             </>
           ) : null}
         </ProfileLinkWrap>
+        <ProfilePadding paddingTop={1.25}>
+          <GlobalButton
+            $isNavy={false}
+            text='회원탈퇴'
+            onClick={() => {
+              if (unregisterAlertRef.current) {
+                unregisterAlertRef.current.showModal()
+              }
+            }}
+          />
+        </ProfilePadding>
+        <Alert
+          ref={unregisterAlertRef}
+          title={ALERT_MESSAGE.UNREGISTER.title}
+          notice={ALERT_MESSAGE.UNREGISTER.notice}
+          actionText={ALERT_MESSAGE.UNREGISTER.actionText}
+          cancelText={ALERT_MESSAGE.UNREGISTER.cancelText}
+          handleAlertClick={async () => {
+            try {
+              await unregisterDelete()
+              localStorage.clear()
+              navigate(ROUTE_PATH.HOME)
+              toast.success('회원탈퇴가 완료되었습니다.')
+            } catch (error) {
+              console.error('회원탈퇴 실패:', error)
+              toast.error('회원탈퇴에 실패했습니다. 다시 시도해주세요.')
+            }
+          }}
+        />
       </section>
     </>
   )


### PR DESCRIPTION
## 🛠️ 구현한 기능
- GlobalNav 컴포넌트 로그인 상태에 따른 조건부 렌더링 구현
- 회원탈퇴 기능 API 연동 및 관련 UI/UX 개선

## 📝 구현한 내용
### 1. GlobalNav 컴포넌트 조건부 렌더링
- `isLogin` 상태에 따라 다음 기능 구현:
  - '메이트 찾기', '굿즈거래', '채팅' 링크를 로그인 상태가 아니면 로그인 페이지로 이동하도록 수정
  - '마이'와 '로그인' 텍스트 및 링크 동적 렌더링
- 코드 가독성과 유지보수를 위한 리팩토링

### 2. 회원탈퇴 기능 구현
- 회원탈퇴 버튼 추가 및 API 연동:
  - `DELETE /members/me` 요청을 전송하는 `unregisterDelete` 함수 구현
  - 요청 성공 시 `localStorage` 비우고 홈 화면으로 리다이렉션
  - 요청 실패/성공 시 `toast`로 메시지 표시
- 회원탈퇴 확인을 위한 모달 추가:
  - `Alert` 컴포넌트를 활용해 회원탈퇴 재확인 UI 구현
  - 회원탈퇴 후 `useUserStore` 상태 초기화

## ✅ 체크리스트
- [x] GlobalNav 로그인 상태에 따른 링크 렌더링 확인
- [x] 회원탈퇴 API 연동 및 정상 동작 확인
- [x] 회원탈퇴 확인 모달과 UX 동작 확인
- [x] 로그인 상태와 관련된 코드 컨벤션 및 가독성 검토 완료

## 💬 리뷰 요구 사항
- GlobalNav 컴포넌트의 조건부 렌더링 로직에 개선점이 있다면 의견 부탁드립니다.
- `Alert` 컴포넌트 활용 방식 개선 필요 여부 검토 요청.
- 회원탈퇴 성공/실패 시 추가적으로 필요한 UI 처리에 대한 의견 부탁드립니다.

## 🔗 연관된 이슈
- close #186
