### PR TITLE
🐛 keepPreviousData로 리렌더링 문제 해결

### DIFF
--- a/src/pages/GoodsListPage/index.tsx
+++ b/src/pages/GoodsListPage/index.tsx
@@ -3,7 +3,7 @@ import { FilterWrap, GoodsCardWrap, TeamSelectWrap } from './style'
 import GoodsCard from '@components/GoodsCard'
 import goodsService from '@apis/goodsService'
 import { useEffect, useState } from 'react'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import FloatButton from '@components/FloatButton'
 import { QUERY_KEY } from '@apis/queryClient'
@@ -28,6 +28,8 @@ const GoodsListPage = () => {
 
       getNextPageParam: (lastPage) =>
         lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
+
+      placeholderData: keepPreviousData, 
     })
 
   const { ref, inView } = useInView()

--- a/src/pages/MateListPage/index.tsx
+++ b/src/pages/MateListPage/index.tsx
@@ -19,7 +19,7 @@ import { kboTeamList } from '@constants/kboInfo'
 import { getMateList } from '@apis/mateListService'
 import MateCard from '@components/MateCard'
 import { useTopRef } from '@hooks/useTopRef'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query'
 import { QUERY_KEY } from '@apis/queryClient'
 import { useInView } from 'react-intersection-observer'
 import MainMateCard from '@components/MainMateCard'
@@ -73,13 +73,13 @@ const MateListPage = () => {
 
       queryFn: ({ pageParam }) =>
         getMateList({ teamId: selectedTeam, ...selectedFilters }, pageParam),
-
       initialPageParam: 0,
 
       getNextPageParam: (lastPage: any) =>
         lastPage.hasNext ? lastPage.pageNumber + 1 : undefined,
-    })
 
+      placeholderData: keepPreviousData,
+    })
   // 무한 스크롤 핸들러
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {


### PR DESCRIPTION
## 🛠️ 구현한 기능
- React Query를 활용한 데이터 유지 및 리렌더링 최적화

## 📝 구현한 내용
- **React Query 최적화**:
  - `useInfiniteQuery`의 `placeholderData` 옵션에 `keepPreviousData`를 적용하여 선택된 팀 및 필터 변경 시 이전 데이터를 유지하면서 리렌더링 최적화.
  - 불필요한 데이터 패칭을 방지하여 성능을 개선.
- **리렌더링 문제 해결**:
  - 팀 선택 및 필터 적용 시 데이터를 유지하며 컴포넌트 리렌더링을 최소화.

## ✅ 체크리스트
- [x] React Query의 `keepPreviousData` 적용으로 데이터 유지 확인
- [x] 리렌더링 문제 해결
- [x] GoodsListPage도 동일한 방법으로 해결 
