### PR TITLE
Feat/#199 로딩 시 min-height 추가 및 smooth 삭제

### DIFF
--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -5,7 +5,7 @@ const ScrollToTopButton = () => {
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
-      behavior: 'smooth',
+      // behavior: 'smooth',
     });
     console.log('페이지 상단으로 이동');
   };

--- a/src/components/TeamSelectSection/index.tsx
+++ b/src/components/TeamSelectSection/index.tsx
@@ -27,7 +27,7 @@ const TeamSelectSection = ({
     const selectedRef = teamRefs.current.get(selectedTeam)
     if (selectedRef) {
       selectedRef.scrollIntoView({
-        behavior: 'smooth',
+        // behavior: 'smooth',
         block: 'nearest',
         inline: 'center',
       })

--- a/src/hooks/useTopRef.ts
+++ b/src/hooks/useTopRef.ts
@@ -5,7 +5,7 @@ export const useTopRef = () => {
 
   const handleUpButtonClick = () => {
     topRef.current?.scrollIntoView({
-      behavior: 'smooth',
+      // behavior: 'smooth',
     })
   }
 

--- a/src/pages/GoodsListPage/style.ts
+++ b/src/pages/GoodsListPage/style.ts
@@ -42,7 +42,8 @@ export const GoodsCardWrap = styled.div`
   align-items: flex-start;
   flex-wrap: wrap;
   gap: 30px 20px;
-
+  min-height: 34em;
+  
   & > a {
     display: block;
     width: calc(50% - 10px);

--- a/src/pages/MainPage/GoodsCardSection/index.tsx
+++ b/src/pages/MainPage/GoodsCardSection/index.tsx
@@ -7,6 +7,9 @@ import { QUERY_KEY } from '@apis/queryClient'
 import fetchApi from '@apis/ky'
 import { GoodsPostSummary } from '@typings/db'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 interface GoodsCardSectionProps {
   selectedTeam: number
@@ -38,7 +41,40 @@ const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
   if (isLoading) {
     return (
       <GoodsCardContainer>
-        <p>로딩 중...</p>
+        <CardWrapper>
+          <Skeleton
+            width='100%'
+            height='16em'
+            borderRadius='0'
+            baseColor={theme.border}
+            highlightColor={theme.fontColor.navy}
+            style={{ marginBottom: '0.5rem' }}
+          />
+          <Skeleton
+            width='100%'
+            height='16em'
+            borderRadius='0'
+            baseColor={theme.border}
+            highlightColor={theme.fontColor.navy}
+            style={{ marginBottom: '0.5rem' }}
+          />
+          <Skeleton
+            width='100%'
+            height='16em'
+            borderRadius='0'
+            baseColor={theme.border}
+            highlightColor={theme.fontColor.navy}
+            style={{ marginBottom: '0.5rem' }}
+          />
+          <Skeleton
+            width='100%'
+            height='16em'
+            borderRadius='0'
+            baseColor={theme.border}
+            highlightColor={theme.fontColor.navy}
+            style={{ marginBottom: '0.5rem' }}
+          />
+        </CardWrapper>
       </GoodsCardContainer>
     )
   }

--- a/src/pages/MainPage/GoodsCardSection/index.tsx
+++ b/src/pages/MainPage/GoodsCardSection/index.tsx
@@ -7,9 +7,6 @@ import { QUERY_KEY } from '@apis/queryClient'
 import fetchApi from '@apis/ky'
 import { GoodsPostSummary } from '@typings/db'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 interface GoodsCardSectionProps {
   selectedTeam: number
@@ -39,44 +36,7 @@ const GoodsCardSection = ({ selectedTeam }: GoodsCardSectionProps) => {
   const teamName = kboTeamList[selectedTeam]?.team || 'KBO'
 
   if (isLoading) {
-    return (
-      <GoodsCardContainer>
-        <CardWrapper>
-          <Skeleton
-            width='100%'
-            height='16em'
-            borderRadius='0'
-            baseColor={theme.border}
-            highlightColor={theme.fontColor.navy}
-            style={{ marginBottom: '0.5rem' }}
-          />
-          <Skeleton
-            width='100%'
-            height='16em'
-            borderRadius='0'
-            baseColor={theme.border}
-            highlightColor={theme.fontColor.navy}
-            style={{ marginBottom: '0.5rem' }}
-          />
-          <Skeleton
-            width='100%'
-            height='16em'
-            borderRadius='0'
-            baseColor={theme.border}
-            highlightColor={theme.fontColor.navy}
-            style={{ marginBottom: '0.5rem' }}
-          />
-          <Skeleton
-            width='100%'
-            height='16em'
-            borderRadius='0'
-            baseColor={theme.border}
-            highlightColor={theme.fontColor.navy}
-            style={{ marginBottom: '0.5rem' }}
-          />
-        </CardWrapper>
-      </GoodsCardContainer>
-    )
+    return <GoodsCardContainer></GoodsCardContainer>
   }
 
   if (isError || goodsCards.length === 0) {

--- a/src/pages/MainPage/GoodsCardSection/style.ts
+++ b/src/pages/MainPage/GoodsCardSection/style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { theme } from '@styles/theme'
 
 export const GoodsCardContainer = styled.div`
-
+  min-height: 32em;
   padding: 0 1.25em;
   border-bottom: 1px solid ${theme.fontColor.cwhite};
 

--- a/src/pages/MainPage/MatchUpSection/index.tsx
+++ b/src/pages/MainPage/MatchUpSection/index.tsx
@@ -19,9 +19,6 @@ import {
   LoadingContainer,
 } from './style'
 import { kboTeamInfo, kboTeamList } from '@constants/kboInfo'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 interface MatchUpSectionProps {
   selectedTeam: number
@@ -49,16 +46,7 @@ const MatchUpSection = ({ selectedTeam }: MatchUpSectionProps) => {
   })
 
   if (isLoading) {
-    return (
-      <Skeleton
-        width='100%'
-        height='11em'
-        borderRadius='0'
-        baseColor={theme.border}
-        highlightColor={theme.fontColor.navy}
-        style={{ marginBottom: '0.5rem' }}
-      />
-    )
+    return <LoadingContainer></LoadingContainer>
   }
   if (matches.length === 0) {
     return (

--- a/src/pages/MainPage/MatchUpSection/index.tsx
+++ b/src/pages/MainPage/MatchUpSection/index.tsx
@@ -16,8 +16,12 @@ import {
   Weather,
   MatchUpContainer,
   PaginationContainer,
+  LoadingContainer,
 } from './style'
 import { kboTeamInfo, kboTeamList } from '@constants/kboInfo'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 interface MatchUpSectionProps {
   selectedTeam: number
@@ -45,9 +49,17 @@ const MatchUpSection = ({ selectedTeam }: MatchUpSectionProps) => {
   })
 
   if (isLoading) {
-    return <div>로딩 중...</div>
+    return (
+      <Skeleton
+        width='100%'
+        height='11em'
+        borderRadius='0'
+        baseColor={theme.border}
+        highlightColor={theme.fontColor.navy}
+        style={{ marginBottom: '0.5rem' }}
+      />
+    )
   }
-
   if (matches.length === 0) {
     return (
       <ErrorContainer>{`${kboTeamList[selectedTeam]?.team}의 매치업 데이터가 없습니다.`}</ErrorContainer>

--- a/src/pages/MainPage/MatchUpSection/style.ts
+++ b/src/pages/MainPage/MatchUpSection/style.ts
@@ -93,8 +93,5 @@ export const Weather = styled.div`
 `;
 
 export const LoadingContainer = styled.div`
-  min-height: 10em;
-  display:grid;
-  align-items: center;
-  justify-content: center; 
+  min-height: 11em;
 `;

--- a/src/pages/MainPage/MatchUpSection/style.ts
+++ b/src/pages/MainPage/MatchUpSection/style.ts
@@ -91,3 +91,10 @@ export const Weather = styled.div`
   font-size: ${theme.fontSize.medium};
   color: ${theme.fontColor.white};
 `;
+
+export const LoadingContainer = styled.div`
+  min-height: 10em;
+  display:grid;
+  align-items: center;
+  justify-content: center; 
+`;

--- a/src/pages/MainPage/MateCardSection/index.tsx
+++ b/src/pages/MainPage/MateCardSection/index.tsx
@@ -7,6 +7,9 @@ import { MateCardContainer, MoreSection } from './style'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { MateCardData, MateCardResponse } from '@typings/db'
 import MainMateCard from '@components/MainMateCard'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 interface MateCardSectionProps {
   selectedTeam: number
@@ -30,7 +33,34 @@ const MateCardSection = ({ selectedTeam }: MateCardSectionProps) => {
   const teamName = kboTeamList[selectedTeam]?.team || 'KBO'
 
   if (isLoading) {
-    return <div>로딩 중...</div>
+    return (
+      <MateCardContainer>
+        <Skeleton
+          width='100%'
+          height='9em'
+          borderRadius='0'
+          baseColor={theme.border}
+          highlightColor={theme.fontColor.navy}
+          style={{ marginBottom: '0.5rem' }}
+        />
+        <Skeleton
+          width='100%'
+          height='9em'
+          borderRadius='0'
+          baseColor={theme.border}
+          highlightColor={theme.fontColor.navy}
+          style={{ marginBottom: '0.5rem' }}
+        />
+        <Skeleton
+          width='100%'
+          height='9em'
+          borderRadius='0'
+          baseColor={theme.border}
+          highlightColor={theme.fontColor.navy}
+          style={{ marginBottom: '0.5rem' }}
+        />
+      </MateCardContainer>
+    )
   }
 
   if (mateCards.length === 0) {

--- a/src/pages/MainPage/MateCardSection/index.tsx
+++ b/src/pages/MainPage/MateCardSection/index.tsx
@@ -7,9 +7,6 @@ import { MateCardContainer, MoreSection } from './style'
 import { ROUTE_PATH } from '@constants/ROUTE_PATH'
 import { MateCardData, MateCardResponse } from '@typings/db'
 import MainMateCard from '@components/MainMateCard'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 interface MateCardSectionProps {
   selectedTeam: number
@@ -33,34 +30,7 @@ const MateCardSection = ({ selectedTeam }: MateCardSectionProps) => {
   const teamName = kboTeamList[selectedTeam]?.team || 'KBO'
 
   if (isLoading) {
-    return (
-      <MateCardContainer>
-        <Skeleton
-          width='100%'
-          height='9em'
-          borderRadius='0'
-          baseColor={theme.border}
-          highlightColor={theme.fontColor.navy}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Skeleton
-          width='100%'
-          height='9em'
-          borderRadius='0'
-          baseColor={theme.border}
-          highlightColor={theme.fontColor.navy}
-          style={{ marginBottom: '0.5rem' }}
-        />
-        <Skeleton
-          width='100%'
-          height='9em'
-          borderRadius='0'
-          baseColor={theme.border}
-          highlightColor={theme.fontColor.navy}
-          style={{ marginBottom: '0.5rem' }}
-        />
-      </MateCardContainer>
-    )
+    return <MateCardContainer></MateCardContainer>
   }
 
   if (mateCards.length === 0) {

--- a/src/pages/MainPage/MateCardSection/style.ts
+++ b/src/pages/MainPage/MateCardSection/style.ts
@@ -7,6 +7,8 @@ export const MoreSection = styled.div`
   border-bottom: 1px solid ${theme.fontColor.cwhite};
 `
 export const MateCardContainer = styled.div`
+  min-height: 27em;
+
   h3 {
     padding: 1em 1.25em;
   }

--- a/src/pages/MainPage/RankingSection/index.tsx
+++ b/src/pages/MainPage/RankingSection/index.tsx
@@ -12,9 +12,6 @@ import { QUERY_KEY } from '@apis/queryClient'
 import { TeamRanking } from '@typings/db'
 import { formatTeamName } from '@utils/formatTeamName'
 import dayjs from 'dayjs'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 const fetchTeamRankings = async (): Promise<TeamRanking[]> => {
   const response = await fetchApi.get('teams/rankings').json<{
@@ -54,18 +51,7 @@ const RankingSection = () => {
   })
 
   if (isLoading) {
-    return (
-      <RankingContainer>
-        <Skeleton
-          width='100%'
-          height='25em'
-          borderRadius='0'
-          baseColor={theme.border}
-          highlightColor={theme.fontColor.navy}
-          style={{ marginBottom: '0.5rem' }}
-        />
-      </RankingContainer>
-    )
+    return <RankingContainer></RankingContainer>
   }
 
   if (isError) {

--- a/src/pages/MainPage/RankingSection/index.tsx
+++ b/src/pages/MainPage/RankingSection/index.tsx
@@ -12,6 +12,9 @@ import { QUERY_KEY } from '@apis/queryClient'
 import { TeamRanking } from '@typings/db'
 import { formatTeamName } from '@utils/formatTeamName'
 import dayjs from 'dayjs'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 const fetchTeamRankings = async (): Promise<TeamRanking[]> => {
   const response = await fetchApi.get('teams/rankings').json<{
@@ -51,7 +54,18 @@ const RankingSection = () => {
   })
 
   if (isLoading) {
-    return <RankingContainer>로딩 중...</RankingContainer>
+    return (
+      <RankingContainer>
+        <Skeleton
+          width='100%'
+          height='25em'
+          borderRadius='0'
+          baseColor={theme.border}
+          highlightColor={theme.fontColor.navy}
+          style={{ marginBottom: '0.5rem' }}
+        />
+      </RankingContainer>
+    )
   }
 
   if (isError) {

--- a/src/pages/MainPage/RankingSection/style.ts
+++ b/src/pages/MainPage/RankingSection/style.ts
@@ -3,7 +3,7 @@ import { theme } from '@styles/theme'
 
 export const RankingContainer = styled.div`
   width: 100%;
-
+  min-height: 25em;
 
   h3 {
     padding: 0.5em 1.25em;

--- a/src/pages/MainPage/ResultSection/ResultList/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultList/index.tsx
@@ -4,15 +4,13 @@ import {
   RivalTeam,
   ResultListTitle,
   ErrorContainer,
+  LoadingContainer
 } from './style'
 import { kboTeamInfo, kboTeamList } from '@constants/kboInfo'
 import fetchApi from '@apis/ky'
 import { QUERY_KEY } from '@apis/queryClient'
 import { Match } from '@typings/db'
 import { formatTeamName } from '@utils/formatTeamName'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 interface ResultListProps {
   teamKey: number // 팀 이름 키
@@ -46,14 +44,7 @@ const ResultList = ({ teamKey }: ResultListProps) => {
 
   if (isLoading) {
     return (
-      <Skeleton
-          width='100%'
-          height='25em'
-          borderRadius='0'
-          baseColor={theme.border}
-          highlightColor={theme.fontColor.navy}
-          style={{ marginBottom: '0.5rem' }}
-        />
+      <LoadingContainer></LoadingContainer>
     )
   }
 

--- a/src/pages/MainPage/ResultSection/ResultList/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultList/index.tsx
@@ -10,6 +10,9 @@ import fetchApi from '@apis/ky'
 import { QUERY_KEY } from '@apis/queryClient'
 import { Match } from '@typings/db'
 import { formatTeamName } from '@utils/formatTeamName'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 interface ResultListProps {
   teamKey: number // 팀 이름 키
@@ -42,7 +45,16 @@ const ResultList = ({ teamKey }: ResultListProps) => {
   })
 
   if (isLoading) {
-    return <p>로딩 중...</p>
+    return (
+      <Skeleton
+          width='100%'
+          height='25em'
+          borderRadius='0'
+          baseColor={theme.border}
+          highlightColor={theme.fontColor.navy}
+          style={{ marginBottom: '0.5rem' }}
+        />
+    )
   }
 
   if (isError || !gameResults.length) {

--- a/src/pages/MainPage/ResultSection/ResultList/style.ts
+++ b/src/pages/MainPage/ResultSection/ResultList/style.ts
@@ -18,7 +18,6 @@ export const ResultListTable = styled.table`
   color: ${theme.fontColor.black};
   margin-bottom: 1.25em;
 
-
   thead {
     display: none;
   }
@@ -102,4 +101,7 @@ export const RivalTeam = styled.div`
     font-size: 14px;
     font-weight: bold;
   }
+`
+export const LoadingContainer = styled.div`
+  min-height: 25em;
 `

--- a/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
@@ -3,6 +3,9 @@ import { kboTeamList } from '@constants/kboInfo'
 import fetchApi from '@apis/ky'
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEY } from '@apis/queryClient'
+import Skeleton from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { theme } from '@styles/theme'
 
 interface TeamRankingData {
   rank: number
@@ -35,7 +38,16 @@ const ResultSummary = ({ selectedTeam }: ResultSummaryProps) => {
     enabled: !!teamId,
   })
 
-  if (isLoading) return <div>로딩 중...</div>
+  if (isLoading) return (
+    <Skeleton
+        width='100%'
+        height='2em'
+        borderRadius='0'
+        baseColor={theme.border}
+        highlightColor={theme.fontColor.navy}
+        style={{ marginBottom: '0.5rem' }}
+      />
+  )
   if (error instanceof Error) return <div>오류: {error.message}</div>
 
   if (!data) return <div>순위 요약 데이터를 불러오지 못했습니다.</div>

--- a/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
+++ b/src/pages/MainPage/ResultSection/ResultSummary/index.tsx
@@ -3,9 +3,6 @@ import { kboTeamList } from '@constants/kboInfo'
 import fetchApi from '@apis/ky'
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_KEY } from '@apis/queryClient'
-import Skeleton from 'react-loading-skeleton'
-import 'react-loading-skeleton/dist/skeleton.css'
-import { theme } from '@styles/theme'
 
 interface TeamRankingData {
   rank: number
@@ -38,16 +35,8 @@ const ResultSummary = ({ selectedTeam }: ResultSummaryProps) => {
     enabled: !!teamId,
   })
 
-  if (isLoading) return (
-    <Skeleton
-        width='100%'
-        height='2em'
-        borderRadius='0'
-        baseColor={theme.border}
-        highlightColor={theme.fontColor.navy}
-        style={{ marginBottom: '0.5rem' }}
-      />
-  )
+  if (isLoading)
+    return <ResultSummaryContainer $teamId={teamId}></ResultSummaryContainer>
   if (error instanceof Error) return <div>오류: {error.message}</div>
 
   if (!data) return <div>순위 요약 데이터를 불러오지 못했습니다.</div>

--- a/src/pages/MainPage/ResultSection/ResultSummary/style.ts
+++ b/src/pages/MainPage/ResultSection/ResultSummary/style.ts
@@ -7,6 +7,7 @@ interface ResultSummaryContainerProps {
 }
 
 export const ResultSummaryContainer = styled.div<ResultSummaryContainerProps>`
+  min-height: 2em;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/pages/MateListPage/index.tsx
+++ b/src/pages/MateListPage/index.tsx
@@ -5,6 +5,7 @@ import {
   FilterSelectOptionWrap,
   FilterWrap,
   TeamSelectWrap,
+  FilteredMateList
 } from './style'
 
 import PillButton from '@components/PillButton'
@@ -120,7 +121,7 @@ const MateListPage = () => {
           )}
         </FilterSelectOptionWrap>
       </FilterWrap>
-      <div>
+      <FilteredMateList>
         {mateList.map((mate) => (
           <MainMateCard
             key={mate.postId}
@@ -128,7 +129,7 @@ const MateListPage = () => {
           />
         ))}
         <div ref={ref} />
-      </div>
+      </FilteredMateList>
 
       <FloatButton
         path={ROUTE_PATH.MATE_POSTING}

--- a/src/pages/MateListPage/style.ts
+++ b/src/pages/MateListPage/style.ts
@@ -67,3 +67,7 @@ export const FilterModalLabel = styled.p`
 export const FilterButtonWrap = styled.div`
   margin-top: 0.75em;
 `
+
+export const FilteredMateList = styled.div`
+  min-height: 34em;
+`


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 메인 페이지, 메이트 리스트 페이지, 굿즈 리스트 페이지에 min-height 추가하여 로딩시 영역 높이를 잡도록 처리
- smooth 속성 삭제

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
-추후 스켈레톤 논의

## 🔗 연관된 이슈
- close (#199 )
