### PR TITLE
✨ Feat : 로그인 상태일 때 마이팀 자동 선택 기능 추가

### DIFF
--- a/src/pages/GoodsListPage/index.tsx
+++ b/src/pages/GoodsListPage/index.tsx
@@ -10,11 +10,18 @@ import { QUERY_KEY } from '@apis/queryClient'
 import PillButton from '@components/PillButton'
 import { useInView } from 'react-intersection-observer'
 import { useTopRef } from '@hooks/useTopRef'
+import { kboTeamList } from '@constants/kboInfo'
 
 const CATEGORY_LIST = ['전체', '유니폼', '모자', '의류', '잡화', '기념상품']
 
 const GoodsListPage = () => {
-  const [selectedTeam, setSelectedTeam] = useState(0)
+  const initialTeam = () => {
+    const token = localStorage.getItem('token')
+    const teamId = localStorage.getItem('teamId')
+    return token && teamId ? Number(teamId) : kboTeamList[0].id
+  }
+
+  const [selectedTeam, setSelectedTeam] = useState<number>(initialTeam)
   const [selectedCategory, setSelectedCategory] = useState('전체')
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -9,7 +9,13 @@ import TeamSelectSection from '@components/TeamSelectSection'
 import { kboTeamList } from '@constants/kboInfo'
 
 const MainPage = () => {
-  const [selectedTeam, setSelectedTeam] = useState<number>(kboTeamList[0].id)
+  const initialTeam = () => {
+    const token = localStorage.getItem('token')
+    const teamId = localStorage.getItem('teamId')
+    return token && teamId ? Number(teamId) : kboTeamList[0].id
+  }
+
+  const [selectedTeam, setSelectedTeam] = useState<number>(initialTeam)
 
   const handleTeamSelect = (team: number) => {
     setSelectedTeam(team)

--- a/src/pages/MateListPage/index.tsx
+++ b/src/pages/MateListPage/index.tsx
@@ -5,7 +5,7 @@ import {
   FilterSelectOptionWrap,
   FilterWrap,
   TeamSelectWrap,
-  FilteredMateList
+  FilteredMateList,
 } from './style'
 
 import PillButton from '@components/PillButton'
@@ -26,9 +26,14 @@ import { useInView } from 'react-intersection-observer'
 import MainMateCard from '@components/MainMateCard'
 
 const MateListPage = () => {
-  const [selectedTeam, setSelectedTeam] = useState<number | null>(
-    kboTeamList[0].id,
-  ) // 팀 선택 상태
+  const initialTeam = () => {
+    const token = localStorage.getItem('token')
+    const teamId = localStorage.getItem('teamId')
+    return token && teamId ? Number(teamId) : kboTeamList[0].id
+  }
+
+  const [selectedTeam, setSelectedTeam] = useState<number | null>(initialTeam)
+
   const { bottomModalRef, handleOpenBottomModal, handleCloseBottomModal } =
     useModal()
 


### PR DESCRIPTION
## 🛠️ 구현한 기능
- `useState` 초기값 설정 로직을 `localStorage`의 값을 참조하도록 수정.

## 📝 구현한 내용
- `initialTeam` 함수를 추가하여 `localStorage`에서 `token`과 `teamId` 값을 읽어 초기값을 계산.
  - `localStorage`에 `token`과 `teamId` 값이 있으면 `Number(teamId)`를 반환.
  - 값이 없으면 기본값으로 `kboTeamList[0].id`를 반환.
- `useState` 초기값을 함수 형태로 전달하여 컴포넌트 마운트 시점에서 초기화.
- 불필요한 `useEffect`를 제거하고 초기값 설정 과정을 간소화.

## ✅ 체크리스트
- [x] `localStorage`의 값을 기준으로 `selectedTeam` 초기값 설정
- [x] `useState` 초기값 설정 로직에서 기본값 처리 확인
- [x] 기존 컴포넌트 동작 유지 확인

## 💬 리뷰 요구 사항
- `initialTeam` 함수의 로직 간결화에 대한 의견 요청
- `useState` 초기화 방식 개선이 적절한지 확인

## 🔗 연관된 이슈
- close #202 
