### PR TITLE
PP / 프로필 페이지 수정사항 반영

### DIFF
--- a/src/apis/userService.ts
+++ b/src/apis/userService.ts
@@ -1,3 +1,4 @@
+import { ProfileEditApiResponse } from '@typings/db'
 import fetchApi from './ky'
 
 const userService = {
@@ -14,7 +15,7 @@ const userService = {
   },
 
   editMyInfo: async (formData: FormData) => {
-    const response = await fetchApi
+    const response: ProfileEditApiResponse = await fetchApi
       .put(`members/me`, {
         body: formData,
       })

--- a/src/components/UserInfoList/index.tsx
+++ b/src/components/UserInfoList/index.tsx
@@ -20,8 +20,10 @@ interface UserInfoListProps {
 const UserInfoList = ({ seller }: UserInfoListProps) => {
   const { nickname, manner, imageUrl, authorId, memberId } = seller
 
+  const userId = memberId || authorId
+
   return (
-    <Link to={`/profile/${memberId ? memberId : authorId}`}>
+    <Link to={`/profile/${userId}`}>
       <DescriptionContainer>
         <ProfileContainer>
           <ProfileBedge

--- a/src/components/UserInfoList/index.tsx
+++ b/src/components/UserInfoList/index.tsx
@@ -4,35 +4,40 @@ import { DescriptionContainer, ProfileContainer, ProfileManner } from './style'
 import ProfileBedge from '@components/ProfileBedge'
 import { GoodsDetail } from '@typings/db'
 import { formatManner } from '@utils/formatManner'
+import { Link } from 'react-router-dom'
 
 interface MateHost {
   manner: number
   nickname: string
   imageUrl: string
+  authorId?: number
+  memberId?: number
 }
 interface UserInfoListProps {
   seller: MateHost | GoodsDetail['seller']
 }
 
 const UserInfoList = ({ seller }: UserInfoListProps) => {
-  const { nickname, manner, imageUrl } = seller
+  const { nickname, manner, imageUrl, authorId, memberId } = seller
 
   return (
-    <DescriptionContainer>
-      <ProfileContainer>
-        <ProfileBedge
-          width={1.875}
-          height={1.875}
-          isChat={true}
-          imageSrc={imageUrl}
-        />
-        <p>{nickname}</p>
-      </ProfileContainer>
-      <p>
-        <ProfileManner>{formatManner(manner)}</ProfileManner>
-        <BatIcon />
-      </p>
-    </DescriptionContainer>
+    <Link to={`/profile/${memberId ? memberId : authorId}`}>
+      <DescriptionContainer>
+        <ProfileContainer>
+          <ProfileBedge
+            width={1.875}
+            height={1.875}
+            isChat={true}
+            imageSrc={imageUrl}
+          />
+          <p>{nickname}</p>
+        </ProfileContainer>
+        <p>
+          <ProfileManner>{formatManner(manner)}</ProfileManner>
+          <BatIcon />
+        </p>
+      </DescriptionContainer>
+    </Link>
   )
 }
 

--- a/src/hooks/useEditMyInfo.ts
+++ b/src/hooks/useEditMyInfo.ts
@@ -1,14 +1,17 @@
 import queryClient, { QUERY_KEY } from '@apis/queryClient'
 import userService from '@apis/userService'
-import { ROUTE_PATH } from '@constants/ROUTE_PATH'
+import { kboTeamInfo } from '@constants/kboInfo'
 import { useMutation } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { ProfileEditApiResponse, ProfileEditResponse } from '@typings/db'
 import { toast } from 'react-toastify'
 
 const useEditMyInfo = (memberId: number) => {
-  const { mutate, isPending, isError, error, isSuccess } = useMutation({
+  const { mutate, isPending, isError, error } = useMutation({
     mutationFn: (formData: FormData) => userService.editMyInfo(formData),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      const response: ProfileEditResponse = data.data
+      localStorage.setItem('teamId', String(kboTeamInfo[response.teamName].id))
+      localStorage.setItem('nickname', response.nickname)
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.MY_INFO, memberId] })
       toast('정보 수정이 완료되었습니다.')
     },
@@ -20,7 +23,7 @@ const useEditMyInfo = (memberId: number) => {
     },
   })
 
-  return { mutateMyInfo: mutate, isPending, isError, error, isSuccess }
+  return { mutateMyInfo: mutate, isPending, isError, error }
 }
 
 export default useEditMyInfo

--- a/src/pages/ChatRoom/Rooms/GoodsChatRoom/GoodsUserCard/index.tsx
+++ b/src/pages/ChatRoom/Rooms/GoodsChatRoom/GoodsUserCard/index.tsx
@@ -1,6 +1,7 @@
 import ProfileBedge from '@components/ProfileBedge'
 import { UserInfo, UserListCardContainer } from './style'
 import { useGoodsChatStore } from '@store/useGoodsChatStore'
+import { Link } from 'react-router-dom'
 
 interface GoodsUserCardProps {
   user: {
@@ -17,20 +18,22 @@ const GoodsUserCard = ({ user }: GoodsUserCardProps) => {
   const isSeller = memberId === currentSellerId
 
   return (
-    <UserListCardContainer>
-      <UserInfo>
-        <ProfileBedge
-          height={3}
-          width={3}
-          imageSrc={imageUrl}
-          isChat={true}
-        />
-        <p>
-          {nickname}
-          {isSeller && <span>(판매자)</span>}
-        </p>
-      </UserInfo>
-    </UserListCardContainer>
+    <Link to={`/profile/${memberId}`}>
+      <UserListCardContainer>
+        <UserInfo>
+          <ProfileBedge
+            height={3}
+            width={3}
+            imageSrc={imageUrl}
+            isChat={true}
+          />
+          <p>
+            {nickname}
+            {isSeller && <span>(판매자)</span>}
+          </p>
+        </UserInfo>
+      </UserListCardContainer>
+    </Link>
   )
 }
 

--- a/src/pages/ChatRoom/Rooms/MateChatRoom/MateUserCard/index.tsx
+++ b/src/pages/ChatRoom/Rooms/MateChatRoom/MateUserCard/index.tsx
@@ -7,6 +7,7 @@ import {
 } from './style'
 import { useMateChatStore } from '@store/useMateChatStore'
 import { MateChatMember } from '@typings/mateChat'
+import { Link } from 'react-router-dom'
 
 interface MateUserCardProps {
   member: MateChatMember
@@ -45,37 +46,39 @@ const MateUserCard = ({ member }: MateUserCardProps) => {
   const isMemberOwner = memberId === Number(localStorage.getItem('memberId'))
 
   return (
-    <UserListCardContainer>
-      <UserInfo>
-        <ProfileBedge
-          height={3}
-          width={3}
-          imageSrc={imageUrl}
-          isChat
-        />
-        <p>
-          {nickname} {isUser && <span>(나)</span>}
-        </p>
-      </UserInfo>
-      <ButtonContainer>
-        {isCompleteRecruit && (
-          <ConfirmationContainer>
-            {!isMemberOwner && (
-              <>
-                <input
-                  type='checkbox'
-                  id={`confirm-${memberId}`}
-                  name={`confirm-${memberId}`}
-                  checked={confirmedParticipants.includes(memberId)}
-                  onChange={handleConfirmation}
-                />
-                <label htmlFor={`confirm-${memberId}`}>참가확인</label>
-              </>
-            )}
-          </ConfirmationContainer>
-        )}
-      </ButtonContainer>
-    </UserListCardContainer>
+    <Link to={`/profile/${member.memberId}`}>
+      <UserListCardContainer>
+        <UserInfo>
+          <ProfileBedge
+            height={3}
+            width={3}
+            imageSrc={imageUrl}
+            isChat
+          />
+          <p>
+            {nickname} {isUser && <span>(나)</span>}
+          </p>
+        </UserInfo>
+        <ButtonContainer>
+          {isCompleteRecruit && (
+            <ConfirmationContainer>
+              {!isMemberOwner && (
+                <>
+                  <input
+                    type='checkbox'
+                    id={`confirm-${memberId}`}
+                    name={`confirm-${memberId}`}
+                    checked={confirmedParticipants.includes(memberId)}
+                    onChange={handleConfirmation}
+                  />
+                  <label htmlFor={`confirm-${memberId}`}>참가확인</label>
+                </>
+              )}
+            </ConfirmationContainer>
+          )}
+        </ButtonContainer>
+      </UserListCardContainer>
+    </Link>
   )
 }
 

--- a/src/pages/MateDetailPage/index.tsx
+++ b/src/pages/MateDetailPage/index.tsx
@@ -96,6 +96,7 @@ const MateDetailPage = () => {
     gender,
     transportType,
     postId,
+    authorId,
   } = matePost
 
   const mateCard = {
@@ -118,6 +119,7 @@ const MateDetailPage = () => {
     nickname,
     imageUrl: userImageUrl,
     rivalMatchTime,
+    authorId,
   }
 
   const handleDeletePost = () => {

--- a/src/pages/ProfilePage/ProfileEdit.tsx
+++ b/src/pages/ProfilePage/ProfileEdit.tsx
@@ -48,11 +48,9 @@ const ProfileEdit = () => {
   const onProfileEditSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const dataObject = {
-      // 팀아이디 수정요청
       teamId: selectedTeamId ? selectedTeamId : currentTeamId,
       nickname: userInfo?.nickname,
       aboutMe: userInfo?.aboutMe,
-      // 멤버아이디 수정요청
       memberId: memberId,
     }
     const formData = new FormData()
@@ -65,6 +63,10 @@ const ProfileEdit = () => {
 
     try {
       mutateMyInfo(formData)
+      dataObject.nickname &&
+        localStorage.setItem('nickname', dataObject.nickname)
+      dataObject.teamId &&
+        localStorage.setItem('teamId', String(dataObject.teamId))
       navigate(`${ROUTE_PATH.PROFILE}/${memberId}`)
     } catch (err) {
       toast('이런! 오류가 발생했어요.')

--- a/src/pages/ProfilePage/ProfileEdit.tsx
+++ b/src/pages/ProfilePage/ProfileEdit.tsx
@@ -40,7 +40,7 @@ const ProfileEdit = () => {
     undefined,
   )
 
-  const { mutateMyInfo, error, isError, isPending, isSuccess } = useEditMyInfo(
+  const { mutateMyInfo, error, isError, isPending } = useEditMyInfo(
     Number(memberId),
   )
 
@@ -63,10 +63,6 @@ const ProfileEdit = () => {
 
     try {
       mutateMyInfo(formData)
-      dataObject.nickname &&
-        localStorage.setItem('nickname', dataObject.nickname)
-      dataObject.teamId &&
-        localStorage.setItem('teamId', String(dataObject.teamId))
       navigate(`${ROUTE_PATH.PROFILE}/${memberId}`)
     } catch (err) {
       toast('이런! 오류가 발생했어요.')

--- a/src/pages/ProfilePage/ProfileMain.tsx
+++ b/src/pages/ProfilePage/ProfileMain.tsx
@@ -4,6 +4,7 @@ import {
   ProfileEditWrap,
   ProfileFollowWrap,
   ProfileLinkWrap,
+  ProfileMainSection,
   ProfileMannerGraph,
   ProfileMannerGraphInner,
   ProfileMannerInfo,
@@ -34,6 +35,8 @@ import { logoutPost } from '@apis/logoutService'
 import { unregisterDelete } from '@apis/unregisterService'
 import { formatManner } from '@utils/formatManner'
 import { toast } from 'react-toastify'
+import { GlobalFloatAside } from '@styles/globalStyle'
+import GlobalNav from '@layouts/GlobalNav'
 
 const ProfileMain = () => {
   const logoutAlertRef = useRef<HTMLDialogElement | null>(null) // 로그아웃용 ref
@@ -113,7 +116,7 @@ const ProfileMain = () => {
         cancelText={ALERT_MESSAGE.LOGOUT.cancelText}
         handleAlertClick={confirmLogout} // 확인 버튼 클릭 시 로그아웃 처리
       />
-      <section>
+      <ProfileMainSection>
         {/* 프로필 상단 섹션 */}
         <ProfileTopWrap>
           <ProfileEditWrap>
@@ -237,36 +240,44 @@ const ProfileMain = () => {
             </>
           ) : null}
         </ProfileLinkWrap>
-        <ProfilePadding paddingTop={1.25}>
-          <GlobalButton
-            $isNavy={false}
-            text='회원탈퇴'
-            onClick={() => {
-              if (unregisterAlertRef.current) {
-                unregisterAlertRef.current.showModal()
-              }
-            }}
-          />
-        </ProfilePadding>
-        <Alert
-          ref={unregisterAlertRef}
-          title={ALERT_MESSAGE.UNREGISTER.title}
-          notice={ALERT_MESSAGE.UNREGISTER.notice}
-          actionText={ALERT_MESSAGE.UNREGISTER.actionText}
-          cancelText={ALERT_MESSAGE.UNREGISTER.cancelText}
-          handleAlertClick={async () => {
-            try {
-              await unregisterDelete()
-              localStorage.clear()
-              navigate(ROUTE_PATH.HOME)
-              toast.success('회원탈퇴가 완료되었습니다.')
-            } catch (error) {
-              console.error('회원탈퇴 실패:', error)
-              toast.error('회원탈퇴에 실패했습니다. 다시 시도해주세요.')
-            }
-          }}
-        />
-      </section>
+        {isMyProfile ? (
+          <>
+            <ProfilePadding paddingTop={1.25}>
+              <GlobalButton
+                $isNavy={false}
+                text='회원탈퇴'
+                onClick={() => {
+                  if (unregisterAlertRef.current) {
+                    unregisterAlertRef.current.showModal()
+                  }
+                }}
+              />
+            </ProfilePadding>
+            <Alert
+              ref={unregisterAlertRef}
+              title={ALERT_MESSAGE.UNREGISTER.title}
+              notice={ALERT_MESSAGE.UNREGISTER.notice}
+              actionText={ALERT_MESSAGE.UNREGISTER.actionText}
+              cancelText={ALERT_MESSAGE.UNREGISTER.cancelText}
+              handleAlertClick={async () => {
+                try {
+                  await unregisterDelete()
+                  localStorage.clear()
+                  navigate(ROUTE_PATH.HOME)
+                  toast.success('회원탈퇴가 완료되었습니다.')
+                } catch (error) {
+                  console.error('회원탈퇴 실패:', error)
+                  toast.error('회원탈퇴에 실패했습니다. 다시 시도해주세요.')
+                }
+              }}
+            />
+          </>
+        ) : null}
+      </ProfileMainSection>
+      {/* 프로필 하단 네비게이션 */}
+      <GlobalFloatAside>
+        <GlobalNav />
+      </GlobalFloatAside>
     </>
   )
 }

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -9,6 +9,10 @@ interface MannerWidth {
   width: number
 }
 
+export const ProfileMainSection = styled.section`
+  padding-bottom: 60px;
+`
+
 export const ProfilePadding = styled.div<ProfilePadding>`
   padding: ${({ paddingTop }) => paddingTop}em 20px;
 `

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -282,3 +282,25 @@ export interface GoodsMessageResponse {
   totalElements: number
   totalPages: number
 }
+
+export interface ProfileEditResponse {
+  aboutMe: string
+  followerCount: number | null
+  followingCount: number | null
+  goodsBoughtCount: number | null
+  goodsSoldCount: number | null
+  imageUrl: string
+  manner: number | null
+  nickname: string
+  reviewsCount: number | null
+  teamName: string
+  visitsCount: number | null
+}
+
+export interface ProfileEditApiResponse {
+  code: number
+  data: ProfileEditResponse
+  message: string | null
+  status: string
+  timestamp: string
+}

--- a/src/typings/db.ts
+++ b/src/typings/db.ts
@@ -62,11 +62,12 @@ export interface GoodsListResponse {
 }
 
 export interface Seller {
-  memberId: number
+  memberId?: number
   nickname: string
   manner: number
   role: string
   imageUrl: string
+  authorId?: number
 }
 
 export interface Location {
@@ -117,7 +118,6 @@ export interface MatePostData {
   postId: number
   authorId: number
   currentChatMembers: number
-
 }
 
 export interface MatePostResponse {


### PR DESCRIPTION
## 🛠️ 구현한 기능
- (프로필 페이지 수정사항 반영

## 📝 구현한 내용
- 프로필 수정후 localStorage값 반영
- 프로필 메인 페이지 하단 네비게이션 추가
- 타인 프로필 페이지 방문시 회원탈퇴 버튼 뜨던거 수정
- 채팅방, 게시글에서 유저 정보 클릭시 유저 프로필 페이지 이동

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 💬 리뷰 요구 사항
- localStorage추가 로직 가능해서 onSuccess로 넘기려다가 그냥 넘기도록 설정했는데 괜찮은지 확인한번 부탁드립니다.

## 🔗 연관된 이슈
- close (#209 )
